### PR TITLE
0-db state monitoring and expansion

### DIFF
--- a/grid_explorer_client/src/lib.rs
+++ b/grid_explorer_client/src/lib.rs
@@ -11,7 +11,7 @@ mod encryption;
 pub mod identity;
 pub mod reservation;
 mod stellar;
-mod types;
+pub mod types;
 pub mod workload;
 
 #[derive(Debug)]
@@ -213,7 +213,9 @@ impl ExplorerClient {
                     }
                 }
             } else {
-                panic!("result should always exist")
+                return Err(ExplorerError::ExplorerClientError(
+                    "workload result state does not exist - explorer issue".into(),
+                ));
             }
         }
         Err(ExplorerError::WorkloadTimeoutError(String::from(

--- a/grid_explorer_client/src/stellar.rs
+++ b/grid_explorer_client/src/stellar.rs
@@ -65,7 +65,7 @@ impl StellarClient {
         let sequence = response.sequence.parse::<i64>().unwrap() + 1;
 
         // memo should be "p-reservation_id"
-        let memo = Memo::new_text(format!("p-{:?}", capacity_pool_information.reservation_id))?;
+        let memo = Memo::new_text(format!("p-{}", capacity_pool_information.reservation_id))?;
         let mut tx =
             Transaction::builder(self.keypair.public_key().clone(), sequence, MIN_BASE_FEE)
                 .with_memo(memo)

--- a/grid_explorer_client/src/types.rs
+++ b/grid_explorer_client/src/types.rs
@@ -3,27 +3,27 @@ use std::net::IpAddr;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Node {
-    id: i64,
-    node_id: String,
-    hostname: String,
-    node_id_v1: String,
-    farm_id: i64,
-    os_version: String,
-    created: u64,
-    uptime: u64,
+    pub id: i64,
+    pub node_id: String,
+    pub hostname: String,
+    pub node_id_v1: String,
+    pub farm_id: i64,
+    pub os_version: String,
+    pub created: u64,
+    pub uptime: u64,
     pub updated: u64,
-    address: String,
-    location: Location,
-    total_resources: ResourceAmount,
-    used_resources: ResourceAmount,
-    reserved_resources: ResourceAmount,
-    workloads: WorkloadAmount,
-    free_to_use: bool,
-    approved: bool,
+    pub address: String,
+    pub location: Location,
+    pub total_resources: ResourceAmount,
+    pub used_resources: ResourceAmount,
+    pub reserved_resources: ResourceAmount,
+    pub workloads: WorkloadAmount,
+    pub free_to_use: bool,
+    pub approved: bool,
     pub public_key_hex: String,
-    wg_ports: Option<Vec<i64>>,
-    deleted: bool,
-    reserved: bool,
+    pub wg_ports: Option<Vec<i64>>,
+    pub deleted: bool,
+    pub reserved: bool,
 }
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Farm {
@@ -81,34 +81,34 @@ enum PriceCurrency {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct Location {
-    city: String,
-    country: String,
-    continent: String,
-    latitude: f64,
-    longitude: f64,
+pub struct Location {
+    pub city: String,
+    pub country: String,
+    pub continent: String,
+    pub latitude: f64,
+    pub longitude: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct ResourceAmount {
-    cru: u64,
-    mru: f64,
-    hru: f64,
-    sru: f64,
+pub struct ResourceAmount {
+    pub cru: u64,
+    pub mru: f64,
+    pub hru: f64,
+    pub sru: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct WorkloadAmount {
-    network: u16,
-    network_resource: u16,
-    volume: u16,
-    zdb_namespace: u16,
-    container: u16,
-    k8s_vm: u16,
-    proxy: u16,
-    reverse_proxy: u16,
-    subdomain: u16,
-    delegate_domain: u16,
+pub struct WorkloadAmount {
+    pub network: u16,
+    pub network_resource: u16,
+    pub volume: u16,
+    pub zdb_namespace: u16,
+    pub container: u16,
+    pub k8s_vm: u16,
+    pub proxy: u16,
+    pub reverse_proxy: u16,
+    pub subdomain: u16,
+    pub delegate_domain: u16,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/zstor/Cargo.toml
+++ b/zstor/Cargo.toml
@@ -48,6 +48,7 @@ actix-rt = "2.2"
 tokio-util = "0.6"
 grid_explorer_client = { path = "../grid_explorer_client" }
 chrono = "0.4"
+serde_json = "1"
 
 [dev-dependencies]
 rand = "0.7"

--- a/zstor/src/actors.rs
+++ b/zstor/src/actors.rs
@@ -1,3 +1,7 @@
+/// Actor to manage multiple 0-db backends. The actor periodically checks the state of the
+/// connection, and capacity of the db. If a connection is down for some time, or the 0-db runs out
+/// of space, there is an attempt to reserve a new one.
+pub mod backends;
 /// Actor implementation of the configuration manager
 pub mod config;
 /// Actor implementation of an explorer client. The actor takes care of managing capacity pools

--- a/zstor/src/actors/backends.rs
+++ b/zstor/src/actors/backends.rs
@@ -144,7 +144,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
             .into_actor(self)
             .map(|res, actor, _| {
                 for (ci, new_state) in res.into_iter() {
-                    // It _IS_ possible that the entryi is gone here, if another future in the
+                    // It _IS_ possible that the entry is gone here, if another future in the
                     // actor runs another future in between. But in this case, it was this actor
                     // which decided to remove the entry, so we don't really care about that
                     // anyway.

--- a/zstor/src/actors/backends.rs
+++ b/zstor/src/actors/backends.rs
@@ -1,0 +1,179 @@
+use crate::actors::config::{ConfigActor, GetConfig};
+use crate::zdb::{SequentialZdb, ZdbConnectionInfo};
+use actix::prelude::*;
+use futures::{stream, StreamExt};
+use log::{debug, error, warn};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// Check backends every 3 seconds.
+const BACKEND_CHECK_INTERVAL_SECONDS: u64 = 2;
+
+/// An actor implementation of a backend manager.
+pub struct BackendManagerActor {
+    config_addr: Addr<ConfigActor>,
+    managed_seq_dbs: HashMap<ZdbConnectionInfo, (Arc<SequentialZdb>, BackendState)>,
+}
+
+impl BackendManagerActor {
+    /// Create a new [`BackendManagerActor`].
+    pub fn new(config_addr: Addr<ConfigActor>) -> BackendManagerActor {
+        Self {
+            config_addr,
+            managed_seq_dbs: HashMap::new(),
+        }
+    }
+
+    /// Send a [`CheckBackends`] command to this actor.
+    fn check_backends(&mut self, ctx: &mut <Self as Actor>::Context) {
+        ctx.notify(CheckBackends);
+    }
+}
+
+/// Message requesting the actor checks the backends, and takes action if a 0-db has reached a
+/// terminal state.
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+struct CheckBackends;
+
+impl Actor for BackendManagerActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        debug!("Backend manager actor started, loading backends to monitor");
+
+        let cfg_addr = self.config_addr.clone();
+
+        ctx.wait(
+            async move {
+                match cfg_addr.send(GetConfig).await {
+                    Err(e) => {
+                        error!("Could not get config: {}", e);
+                        // we won't manage the dbs
+                        HashMap::new()
+                    }
+                    Ok(config) => {
+                        stream::iter(config.backends())
+                            .filter_map(|ci| async move {
+                                let db = match SequentialZdb::new(ci.clone()).await {
+                                    Ok(db) => db,
+                                    Err(e) => {
+                                        warn!(
+                                            "Could not connect to backend {} in config file: {}",
+                                            ci, e
+                                        );
+                                        // We can't track the db here as we don't have an object to
+                                        // track.
+                                        // TODO
+                                        return None;
+                                    }
+                                };
+                                let db = Arc::new(db);
+                                let ns_info = match db.ns_info().await {
+                                    Ok(info) => info,
+                                    Err(e) => {
+                                        warn!("Failed to get ns info from backend {}: {}", ci, e);
+                                        return Some((
+                                            ci.clone(),
+                                            (db, BackendState::Unknown(Instant::now())),
+                                        ));
+                                    }
+                                };
+
+                                let free_space = ns_info.free_space();
+                                let state = if free_space <= FREESPACE_TRESHOLD {
+                                    BackendState::LowSpace(free_space)
+                                } else {
+                                    BackendState::Healthy
+                                };
+
+                                Some((ci.clone(), (db, state)))
+                            })
+                            .collect()
+                            .await
+                    }
+                }
+            }
+            .into_actor(self)
+            .map(|res, actor, _| actor.managed_seq_dbs = res),
+        );
+
+        ctx.run_interval(
+            Duration::from_secs(BACKEND_CHECK_INTERVAL_SECONDS),
+            Self::check_backends,
+        );
+    }
+}
+
+impl Handler<CheckBackends> for BackendManagerActor {
+    type Result = ResponseActFuture<Self, ()>;
+
+    fn handle(&mut self, _: CheckBackends, _: &mut Self::Context) -> Self::Result {
+        todo!();
+    }
+}
+
+/// Amount of time a backend can be unreachable before it is actually considered unreachable.
+/// Currently set to 15 minutes.
+const MISSING_DURATION: Duration = Duration::from_secs(15 * 60);
+/// The amount of free space left in a backend before it is considered to be full. Currently this is
+/// 100 MiB.
+const FREESPACE_TRESHOLD: u64 = 100 * (1 << 20);
+
+#[derive(Debug, PartialEq)]
+/// Information about the state of a backend.
+pub enum BackendState {
+    /// The state can't be decided at the moment. The time at which we last saw this backend healthy
+    /// is also recorded
+    Unknown(Instant),
+    /// The backend is healthy and has sufficient free space available.
+    Healthy,
+    /// The backend is (supposedly permanently) unreachable.
+    Unreachable,
+    /// The shard reports low space, amount of space left is included in bytes
+    LowSpace(u64),
+}
+
+impl BackendState {
+    /// Indicate that the backend is (currently) unreachable. Depending on the previous state, this
+    /// might change the state.
+    pub fn mark_unreachable(&mut self) {
+        match self {
+            BackendState::Unreachable => {}
+            BackendState::Unknown(since) if since.elapsed() >= MISSING_DURATION => {
+                debug!("Backend state changed to unreachable");
+                *self = BackendState::Unreachable;
+            }
+            BackendState::Unknown(since) if since.elapsed() < MISSING_DURATION => (),
+            _ => *self = BackendState::Unknown(Instant::now()),
+        }
+    }
+
+    /// Indicate that the backend is healthy, and has the given amount of space left. Depending on
+    /// the provided space, this might transition the backend into [`BackendState::LowSpace`] state.
+    pub fn mark_healthy(&mut self, space_left: u64) {
+        if space_left <= FREESPACE_TRESHOLD {
+            *self = BackendState::LowSpace(space_left)
+        } else {
+            *self = BackendState::Healthy
+        }
+    }
+
+    /// Identify if the backend is considered readable.
+    pub fn is_readable(&self) -> bool {
+        // we still consider unknown state to be readable.
+        *self != BackendState::Unreachable
+    }
+
+    /// Identify if the backend is considered writeable.
+    pub fn is_writeable(&self) -> bool {
+        match self {
+            BackendState::Unreachable => false,
+            BackendState::LowSpace(size) if *size <= FREESPACE_TRESHOLD => false,
+            _ => true,
+        }
+    }
+}

--- a/zstor/src/actors/explorer.rs
+++ b/zstor/src/actors/explorer.rs
@@ -1,13 +1,27 @@
-use crate::actors::config::ConfigActor;
+use crate::actors::config::{AddZdb, ConfigActor, GetConfig};
+use crate::{
+    config::Group,
+    zdb::{ZdbConnectionInfo, ZdbRunMode},
+    ZstorError, ZstorErrorKind,
+};
 use actix::prelude::*;
 use chrono::{TimeZone, Utc};
 use futures::future::join_all;
 use grid_explorer_client::{
     reservation::{PoolData, ReservationData},
+    types::Node,
+    workload::{DiskType, WorkloadType, ZdbInformationBuilder, ZdbMode},
     ExplorerClient,
 };
-use log::{debug, error};
-use std::{sync::Arc, time::Duration};
+use log::{debug, error, warn};
+use rand::{distributions::Alphanumeric, seq::SliceRandom, Rng};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
 /// The amount of seconds between each pool check.
 const POOL_CHECK_INTERVAL_SECONDS: u64 = 60 * 60;
@@ -23,20 +37,19 @@ const TFT_CURRENCY_ID: &str = "TFT";
 /// Actor managing reservatonson the threefold grid with an attached stellar wallet.
 pub struct ExplorerActor {
     client: Arc<ExplorerClient>,
-    // TODO
-    _cfg_addr: Addr<ConfigActor>,
-    managed_pools: Vec<PoolData>,
+    cfg_addr: Addr<ConfigActor>,
+    managed_pools: HashMap<i64, PoolData>,
 }
 
 impl ExplorerActor {
     /// Create a new [`ExplorerActor`] from an existing [`ExplorerClient`], and a
     /// [`ConfigActor`].
-    pub fn new(client: ExplorerClient, _cfg_addr: Addr<ConfigActor>) -> ExplorerActor {
+    pub fn new(client: ExplorerClient, cfg_addr: Addr<ConfigActor>) -> ExplorerActor {
         let client = Arc::new(client);
         Self {
             client,
-            _cfg_addr,
-            managed_pools: Vec::new(),
+            cfg_addr,
+            managed_pools: HashMap::new(),
         }
     }
 
@@ -51,6 +64,22 @@ impl ExplorerActor {
 #[derive(Debug, Message)]
 #[rtype(result = "()")]
 struct CheckPools;
+
+/// Message requesting the actor to expand the backend storage. An optional existing reservation
+/// ID can be passed. In this case, an attempt is made to reserve the storage on the same pool. If
+/// the decomission flag is passed as well, the old reservation is attempted to be removed.
+#[derive(Debug, Message)]
+#[rtype(result = "Result<ZdbConnectionInfo, ZstorError>")]
+pub struct ExpandStorage {
+    /// An optional existing 0-db to remove.
+    pub existing_zdb: Option<ZdbConnectionInfo>,
+    /// Whether the existing reservation should be decomissioned.
+    pub decomission: bool,
+    /// Size in GiB for the new 0-db namespace.
+    pub size_gib: u64,
+    /// The mode the new 0-db should run in.
+    pub mode: ZdbRunMode,
+}
 
 impl Actor for ExplorerActor {
     type Context = Context<Self>;
@@ -77,7 +106,8 @@ impl Actor for ExplorerActor {
                                     .collect::<Vec<_>>()
                                     .join(",")
                             );
-                            actor.managed_pools = pools;
+                            actor.managed_pools =
+                                pools.into_iter().map(|pd| (pd.pool_id, pd)).collect();
                         }
                     };
                 }),
@@ -92,8 +122,8 @@ impl Actor for ExplorerActor {
             "Explorer actor initialization finished, managing {} pools (ids {})",
             self.managed_pools.len(),
             self.managed_pools
-                .iter()
-                .map(|pool| pool.pool_id.to_string())
+                .keys()
+                .map(|id| id.to_string())
                 .collect::<Vec<_>>()
                 .join(",")
         );
@@ -101,7 +131,7 @@ impl Actor for ExplorerActor {
 }
 
 impl Handler<CheckPools> for ExplorerActor {
-    type Result = ResponseFuture<()>;
+    type Result = ResponseActFuture<Self, ()>;
 
     fn handle(&mut self, _: CheckPools, _: &mut Self::Context) -> Self::Result {
         debug!("Attempting to refresh pool expiration");
@@ -112,49 +142,330 @@ impl Handler<CheckPools> for ExplorerActor {
         let pools_to_extend = self
             .managed_pools
             .iter()
-            .filter(|pool| {
+            .filter_map(|(id, pool)| {
                 let expiration = Utc.timestamp(pool.empty_at, 0);
                 if (expiration - now).num_seconds() <= POOL_REFRESH_LIFETIME_SECONDS as i64 {
                     // Found a pool which is about to expire, start refresh operaton
-                    debug!(
-                        "Pool {} is about to expire, attempting to refresh",
-                        pool.pool_id
-                    );
-                    return true;
+                    debug!("Pool {} is about to expire, attempting to refresh", id);
+                    return Some(pool);
                 };
-                false
+                None
             })
             .cloned()
             .collect::<Vec<_>>();
 
-        Box::pin(async move {
-            let extensions = pools_to_extend.iter().map(|pool| {
-                let missing_cu = pool.active_cu * POOL_TARGET_LIFETIME_SECONDS as f64 - pool.cus;
-                let missing_su = pool.active_su * POOL_TARGET_LIFETIME_SECONDS as f64 - pool.sus;
+        Box::pin(
+            async move {
+                let extensions = pools_to_extend.iter().map(|pool| {
+                    let missing_cu =
+                        pool.active_cu * POOL_TARGET_LIFETIME_SECONDS as f64 - pool.cus;
+                    let missing_su =
+                        pool.active_su * POOL_TARGET_LIFETIME_SECONDS as f64 - pool.sus;
 
-                let rd = ReservationData {
-                    pool_id: pool.pool_id,
-                    cus: missing_cu.ceil() as u64,
-                    sus: missing_su.ceil() as u64,
-                    ipv4us: 0,
-                    node_ids: pool.node_ids.clone(),
-                    currencies: vec![String::from(TFT_CURRENCY_ID)],
-                };
+                    let rd = ReservationData {
+                        pool_id: pool.pool_id,
+                        cus: missing_cu.ceil() as u64,
+                        sus: missing_su.ceil() as u64,
+                        ipv4us: 0,
+                        node_ids: pool.node_ids.clone(),
+                        currencies: vec![String::from(TFT_CURRENCY_ID)],
+                    };
 
-                client.create_capacity_pool(rd)
-            });
+                    client.create_capacity_pool(rd)
+                });
 
-            for result in join_all(extensions).await {
-                match result {
-                    Err(e) => error!("Failed to extend pool: {}", e),
-                    Ok(success) if !success => {
-                        error!("Got unexpected failed response from explorer")
+                for result in join_all(extensions).await {
+                    match result {
+                        Err(e) => error!("Failed to extend pool: {}", e),
+                        Ok(success) if !success => {
+                            error!("Got unexpected failed response from explorer")
+                        }
+                        Ok(success) if success => debug!("Successfully extended pool"),
+                        // compiler does not understand that we exhauted al bool options above
+                        Ok(_) => unreachable!(),
                     }
-                    Ok(success) if success => debug!("Successfully extended pool"),
-                    // compiler does not understand that we exhauted al bool options above
-                    Ok(_) => unreachable!(),
+                }
+
+                // Fetch all pools again to get latest status.
+                client.pools_by_owner().await
+            }
+            .into_actor(self)
+            .map(|pools, actor, _| match pools {
+                Err(e) => error!("Failed to refresh pools: {}", e),
+                Ok(pools) => {
+                    debug!("Reloaded existing capacity pools");
+                    actor.managed_pools = pools.into_iter().map(|pd| (pd.pool_id, pd)).collect();
+                }
+            }),
+        )
+    }
+}
+
+impl Handler<ExpandStorage> for ExplorerActor {
+    type Result = ResponseFuture<Result<ZdbConnectionInfo, ZstorError>>;
+
+    fn handle(&mut self, msg: ExpandStorage, _: &mut Self::Context) -> Self::Result {
+        let client = self.client.clone();
+        let own_pools = self.managed_pools.clone();
+        let own_pool_ids = self.managed_pools.keys().copied().collect::<Vec<_>>();
+        let cfg_actor = self.cfg_addr.clone();
+
+        Box::pin(async move {
+            if own_pool_ids.is_empty() {
+                return Err(ZstorError::with_message(
+                    ZstorErrorKind::Explorer,
+                    "Can't reserve a new 0-db as we are currently not managing any pools".into(),
+                ));
+            }
+            let existing_reservation_id = if let Some(ref ci) = msg.existing_zdb {
+                ci.reservation_id()
+            } else {
+                None
+            };
+            // Try to select a new node from the same pool to deploy on.
+            let mut prefered_node_id: Option<(i64, String, String)> = if let Some(id) =
+                existing_reservation_id
+            {
+                let old_workload = client.workload_get_by_id(id).await?;
+                let pool_id = old_workload.pool_id;
+                // prefer to work on the same pool
+                if !own_pool_ids.contains(&pool_id) {
+                    warn!("Attempting to get new storage from existing storage which is not managed by our own pools (pool_id: {})", pool_id);
+                    None
+                } else {
+                    // unwrap here is safe since we selected a pool id we own above.
+                    let mut pref = None;
+                    for node_id in &own_pools.get(&pool_id).unwrap().node_ids {
+                        if node_id == &old_workload.node_id && msg.decomission {
+                            continue;
+                        }
+                        let node = client.node_get_by_id(&node_id).await?;
+                        if is_deployable(&node, msg.size_gib) {
+                            pref = Some((pool_id, node_id.clone(), node.public_key_hex));
+                            break;
+                        }
+                    }
+                    pref
+                }
+            } else {
+                None
+            };
+
+            // TODO: Selecting a random pool here might break the redundancy configuration
+            if prefered_node_id.is_none() {
+                // Randomly select from all pools.
+                // First create a list of (pool_id, node_id)
+                let mut nodes = own_pools
+                    .into_iter()
+                    .map(|(id, pool)| {
+                        pool.node_ids
+                            .into_iter()
+                            .map(|nid| (id, nid))
+                            .collect::<Vec<_>>()
+                    })
+                    .flatten()
+                    .collect::<Vec<_>>();
+
+                // Shuffle nodes list, so they are in random order
+                nodes.shuffle(&mut rand::thread_rng());
+
+                // Now pick the first acceptable node
+                for (pool_id, node_id) in nodes.into_iter() {
+                    let node = client.node_get_by_id(&node_id).await?;
+                    if is_deployable(&node, msg.size_gib) {
+                        prefered_node_id = Some((pool_id, node_id, node.public_key_hex));
+                        break;
+                    }
                 }
             }
+
+            if prefered_node_id.is_none() {
+                error!(
+                    "Unable to find valid node to deploy new 0-db on of size {}",
+                    msg.size_gib
+                );
+            }
+
+            // Unwrap is safe as we just checked that this is Some(_).
+            let (pool_id, node_id, node_pubkey) = prefered_node_id.unwrap();
+            // Generate a new password. This is included in the connection info later.
+            let pwd: String = rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(30)
+                .map(char::from)
+                .collect();
+            let res = ZdbInformationBuilder::new()
+                .size(msg.size_gib as i64)
+                .mode(match msg.mode {
+                    ZdbRunMode::Seq => ZdbMode::ZdbModeSeq,
+                    ZdbRunMode::User => ZdbMode::ZdbModeUser,
+                })
+                .public(false)
+                .disk_type(DiskType::Hdd)
+                .password(pwd.clone())
+                .build(&client.user_identity, &node_pubkey)
+                .expect("We should have filled in all 0-db information required");
+
+            let wid = client.create_zdb_reservation(node_id, pool_id, res).await?;
+
+            // Wait for 3 minutes for deployment, this should be more than sufficient
+            let workload = match client.workload_poll(wid, 60 * 3).await {
+                Err(e) => {
+                    error!("Could not deploy workload (in 3 minutes): {}", e);
+                    // Try to decommission the workload again.
+                    if let Err(e) = client.workload_decommission(wid).await {
+                        error!("Could not decommission failed workload: {}", e);
+                    }
+                    return Err(e.into());
+                }
+                Ok(w) => {
+                    debug!("Workload {} deployed successfully", wid);
+                    w
+                }
+            };
+
+            // This unwrap is safe since the poll call above only returns Ok(_) if this is Some(_).
+            let result = workload.result.unwrap();
+            let res = match serde_json::value::from_value::<ZdbResultJson>(result.data_json) {
+                Err(e) => {
+                    error!("Failed to parse 0-db reservation result: {}", e);
+                    // Try to decommission the workload again.
+                    if let Err(e) = client.workload_decommission(wid).await {
+                        error!("Could not decommission failed workload: {}", e);
+                    }
+                    return Err(ZstorError::with_message(
+                        ZstorErrorKind::Explorer,
+                        "Failed to parse 0-db reservation result".into(),
+                    ));
+                }
+                Ok(res) => res,
+            };
+
+            if res.ips.is_empty() {
+                error!("0-db reservation did not provide any IPs");
+                // Try to decommission the workload again.
+                if let Err(e) = client.workload_decommission(wid).await {
+                    error!("Could not decommission failed workload: {}", e);
+                }
+                return Err(ZstorError::with_message(
+                    ZstorErrorKind::Explorer,
+                    "0-db reservation did not provide any IPs".into(),
+                ));
+            }
+
+            let ci = ZdbConnectionInfo::new(
+                SocketAddr::new(res.ips[0], res.port),
+                Some(res.namespace),
+                Some(pwd),
+            );
+
+            // delete old zdb if needed
+            if let Some(wid) = existing_reservation_id {
+                debug!("Decommissioning existing workload {}", wid);
+                if let Err(e) = client.workload_decommission(wid).await {
+                    error!("Could not decommission old workload {}: {}", wid, e);
+                }
+            }
+            // Now we need to insert the CI in the proper config group
+            let cfg = cfg_actor.send(GetConfig).await?;
+
+            for (idx, group) in cfg.groups().iter().enumerate() {
+                let group_pool = group_pool(client.clone(), group).await;
+                if let Some(pid) = group_pool {
+                    if pool_id == pid {
+                        cfg_actor
+                            .send(AddZdb {
+                                group_idx: idx,
+                                ci: ci.clone(),
+                                replaced: msg.existing_zdb,
+                            })
+                            .await??;
+                        return Ok(ci);
+                    }
+                }
+            }
+
+            // If we get here it means we couldn't identify the group, start a new one
+            cfg_actor
+                .send(AddZdb {
+                    group_idx: cfg.groups().len(),
+                    ci: ci.clone(),
+                    replaced: msg.existing_zdb,
+                })
+                .await??;
+
+            Ok(ci)
         })
     }
+}
+
+/// Attempt to find the primary pool of a group. If there are too many unknown 0-dbs in the group,
+/// or they belong to too many different pools, [`Option::None`] is returned.
+// TODO: returns farms here
+async fn group_pool(client: Arc<ExplorerClient>, group: &Group) -> Option<i64> {
+    let mut pools: HashMap<i64, usize> = HashMap::new();
+    for ci in group.backends() {
+        if let Some(res_id) = ci.reservation_id() {
+            let reservation = match client.workload_get_by_id(res_id).await {
+                Err(e) => {
+                    warn!("Could not load 0-db reservation: {}", e);
+                    continue;
+                }
+                Ok(res) => res,
+            };
+
+            if reservation.workload_type != WorkloadType::WorkloadTypeZdb {
+                warn!("Reservation has wrong type {}", reservation.workload_type);
+                continue;
+            }
+
+            *pools.entry(reservation.pool_id).or_insert(0) += 1;
+        }
+    }
+
+    // Find the pool with the most attached 0-dbs in the group.
+    let most_frequent_pool = pools.iter().max_by(|a, b| a.1.cmp(&b.1)).map(|(k, _)| k);
+    if let Some(id) = most_frequent_pool {
+        // make sure at least half of the 0-dbs belong to the same pool, otherwise return [`None`]
+        // to indicate that we don't know.
+        if *id as usize >= group.backends().len() {
+            return Some(*id);
+        }
+    }
+    None
+}
+
+/// Check if a node is acceptable to deploy a new 0-db on with a given size.
+fn is_deployable(node: &Node, size: u64) -> bool {
+    if node.deleted {
+        return false;
+    }
+    if node.reserved {
+        return false;
+    }
+    // check node is online
+    if (Utc::now() - Utc.timestamp(node.updated as i64, 0)).num_seconds() > 600 {
+        return false;
+    }
+
+    // Make sure node has enough free hru
+    if ((node.total_resources.hru - node.used_resources.hru - node.reserved_resources.hru).floor()
+        as u64)
+        < size
+    {
+        return false;
+    }
+
+    true
+}
+
+/// The json structure of the response in a 0-db reservation
+#[derive(Debug, Serialize, Deserialize)]
+struct ZdbResultJson {
+    #[serde(rename = "Namespace")]
+    namespace: String,
+    #[serde(rename = "IPs")]
+    ips: Vec<IpAddr>,
+    #[serde(rename = "Port")]
+    port: u16,
 }

--- a/zstor/src/zdb.rs
+++ b/zstor/src/zdb.rs
@@ -227,16 +227,23 @@ impl Stream for CollectionKeys {
     }
 }
 
-impl Drop for CollectionKeys {
-    fn drop(&mut self) {}
-}
-
 /// Connection info for a 0-db (namespace).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ZdbConnectionInfo {
     address: SocketAddr,
     namespace: Option<String>,
     password: Option<String>,
+}
+
+impl fmt::Display for ZdbConnectionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            self.address,
+            self.namespace.as_deref().unwrap_or("[default namespace]")
+        )
+    }
 }
 
 impl ZdbConnectionInfo {

--- a/zstor/src/zdb.rs
+++ b/zstor/src/zdb.rs
@@ -262,6 +262,33 @@ impl ZdbConnectionInfo {
         &self.address
     }
 
+    /// Get a possible reservation id from the [`ZdbConnectionInfo`].
+    pub fn reservation_id(&self) -> Option<i64> {
+        // A namespace usually takes the form of {wid}-{index}, so split on '-', and check if we
+        // have 2 numbers.
+        if let Some(ns) = &self.namespace {
+            let mut parts = ns.split('-');
+            let id = if let Some(head) = parts.next() {
+                match head.parse::<i64>() {
+                    Err(_) => return None,
+                    Ok(id) => id,
+                }
+            } else {
+                return None;
+            };
+            if let Some(trail) = parts.next() {
+                if trail.parse::<u64>().is_err() {
+                    return None;
+                }
+            }
+            if parts.next().is_some() {
+                return None;
+            }
+            return Some(id);
+        }
+        None
+    }
+
     /// Get a hash of the connection info using the blake2b hash algorithm. The output size is 16
     /// bytes.
     pub fn blake2_hash(&self) -> [u8; 16] {


### PR DESCRIPTION
Add monitoring of state of the managed 0-db backends (i.e. the backends in the config). If a 0-db is low on space, a new one will be reserved in its place. If it becomes unreachable, it will be decommissioned and a new one reserved in its place. An attempt is made to reserve the new backend on the same farm, and to add it to the correct group in the config file.

Closes #49
Closes #50
Closes #51