### PR TITLE
add index recovery and move stats to a sync actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-clean"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,6 +3837,7 @@ dependencies = [
  "log4rs",
  "nix",
  "openssl",
+ "path-clean",
  "pretty_env_logger",
  "prometheus",
  "rand 0.7.3",

--- a/zstor/Cargo.toml
+++ b/zstor/Cargo.toml
@@ -35,7 +35,7 @@ sha-1 = "0.9"
 simple_logger = "1.11" # TODO: remove this
 pretty_env_logger = "0.4"
 structopt = "0.3"
-tokio = { version = "1", features = ["rt", "macros", "fs", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "macros", "fs"] }
 futures = "0.3"
 blake2 = "0.9"
 gray-codes = "0.1"

--- a/zstor/Cargo.toml
+++ b/zstor/Cargo.toml
@@ -35,7 +35,7 @@ sha-1 = "0.9"
 simple_logger = "1.11" # TODO: remove this
 pretty_env_logger = "0.4"
 structopt = "0.3"
-tokio = { version = "1", features = ["rt", "macros", "fs"] }
+tokio = { version = "1", features = ["rt", "macros", "fs", "rt-multi-thread"] }
 futures = "0.3"
 blake2 = "0.9"
 gray-codes = "0.1"
@@ -52,6 +52,7 @@ serde_json = "1"
 prometheus = "0.12"
 tide = "0.16"
 nix = "0.22"
+path-clean = "0.1.0"
 
 [build-dependencies]
 bindgen = "0.59"

--- a/zstor/src/actors/zdbfs.rs
+++ b/zstor/src/actors/zdbfs.rs
@@ -15,7 +15,11 @@ const DEFAULT_ZDBFS_STATS_INTERVAL_SECS: u64 = 1;
 pub struct ZdbFsStatsActor {
     stats: Option<ZdbFsStats>,
 }
-
+impl Default for ZdbFsStatsActor {
+    fn default() -> Self {
+        ZdbFsStatsActor::new()
+    }
+}
 impl ZdbFsStatsActor {
     /// Create a new ZdbFsStatsActor, which will get statistics and push them to the metrics actor
     /// at a given interval.

--- a/zstor/src/actors/zdbfs.rs
+++ b/zstor/src/actors/zdbfs.rs
@@ -1,18 +1,18 @@
 use crate::actors::metrics::{MetricsActor, UpdateZdbFsStats};
 use crate::zdbfs::ZdbFsStats;
-use actix::prelude::*;
-use std::path::{PathBuf};
 use crate::ZstorError;
-use log::warn;
-use std::time::Duration;
-use tokio::time::sleep;
-use tokio::runtime::Runtime;
+use actix::prelude::*;
 use log::debug;
+use log::warn;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::time::sleep;
 // use thread::{sleep};
 const DEFAULT_ZDBFS_STATS_INTERVAL_SECS: u64 = 1;
 
 /// An actor implementation of a periodic 0-db-fs statistic getter.
-pub struct ZdbFsStatsActor{
+pub struct ZdbFsStatsActor {
     stats: Option<ZdbFsStats>,
 }
 
@@ -20,18 +20,16 @@ impl ZdbFsStatsActor {
     /// Create a new ZdbFsStatsActor, which will get statistics and push them to the metrics actor
     /// at a given interval.
     pub fn new() -> Self {
-        ZdbFsStatsActor{
-            stats: None
-        }
+        ZdbFsStatsActor { stats: None }
     }
     fn renew_fd(&mut self, path: PathBuf) {
         debug!("renewing stats fd");
         let zdbfs_stats = ZdbFsStats::try_new(path)
-        .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats".into(), e));
+            .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats".into(), e));
         match zdbfs_stats {
             Ok(v) => {
                 self.stats = Some(v);
-            },
+            }
             Err(e) => {
                 warn!("couldn't get a new zdbbfs stats {}", e);
                 self.stats = None;
@@ -58,8 +56,7 @@ impl Message for LoopOverStats {
 impl Handler<LoopOverStats> for ZdbFsStatsActor {
     type Result = Result<u64, ()>;
     fn handle(&mut self, msg: LoopOverStats, _: &mut Self::Context) -> Self::Result {
-        let rt = Runtime::new()
-            .unwrap();
+        let rt = Runtime::new().unwrap();
         loop {
             match &self.stats {
                 None => self.renew_fd(msg.buf.clone()),

--- a/zstor/src/actors/zdbfs.rs
+++ b/zstor/src/actors/zdbfs.rs
@@ -57,13 +57,7 @@ impl Handler<ProbeStatsActor> for ZdbFsStatsProxyActor {
         let metrics = self.metrics.clone();
         let stats_actor = self.stats_actor.clone();
         Box::pin(async move {
-            if let Err(e) = stats_actor
-                .send(ProcessStats {
-                    buf: buf.clone(),
-                    metrics: metrics.clone(),
-                })
-                .await
-            {
+            if let Err(e) = stats_actor.send(ProcessStats { buf, metrics }).await {
                 warn!("couldn't process zdbfs stats: {}", e);
             }
         })
@@ -124,7 +118,7 @@ impl Handler<ProcessStats> for ZdbFsStatsActor {
     type Result = Result<(), ZstorError>;
     fn handle(&mut self, msg: ProcessStats, _: &mut Self::Context) -> Self::Result {
         if self.stats.is_none() {
-            self.renew_fd(msg.buf.clone())?;
+            self.renew_fd(msg.buf)?;
         }
         match self
             .stats

--- a/zstor/src/actors/zdbfs.rs
+++ b/zstor/src/actors/zdbfs.rs
@@ -5,87 +5,142 @@ use actix::prelude::*;
 use log::debug;
 use log::warn;
 use std::path::PathBuf;
-use std::time::Duration;
-use tokio::runtime::Runtime;
-use tokio::time::sleep;
+use tokio::time;
 // use thread::{sleep};
 const DEFAULT_ZDBFS_STATS_INTERVAL_SECS: u64 = 1;
+/// An async zdbfs stats actor for the sync actor
+pub struct ZdbFsStatsProxyActor {
+    /// Path buffer to zdbfs mountpoint
+    pub buf: PathBuf,
+    /// Metrics actor address
+    pub metrics: Addr<MetricsActor>,
+    /// ZdbFs stats actor address
+    stats_actor: Addr<ZdbFsStatsActor>,
+}
+
+impl ZdbFsStatsProxyActor {
+    /// Create a new zdbfs stats proxy actor
+    pub fn new(buf: PathBuf, metrics: Addr<MetricsActor>) -> Self {
+        let stats_actor = SyncArbiter::start(1, ZdbFsStatsActor::new);
+        ZdbFsStatsProxyActor {
+            buf,
+            metrics,
+            stats_actor,
+        }
+    }
+    fn probe_stats(&mut self, ctx: &mut <Self as Actor>::Context) {
+        ctx.notify(ProbeStatsActor);
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+/// Probes the sync actor to process metrics
+struct ProbeStatsActor;
+
+impl Actor for ZdbFsStatsProxyActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        ctx.run_interval(
+            time::Duration::from_secs(DEFAULT_ZDBFS_STATS_INTERVAL_SECS),
+            Self::probe_stats,
+        );
+    }
+}
+
+impl Handler<ProbeStatsActor> for ZdbFsStatsProxyActor {
+    type Result = ResponseFuture<()>;
+
+    fn handle(&mut self, _: ProbeStatsActor, _: &mut Self::Context) -> Self::Result {
+        let buf = self.buf.clone();
+        let metrics = self.metrics.clone();
+        let stats_actor = self.stats_actor.clone();
+        Box::pin(async move {
+            if let Err(e) = stats_actor
+                .send(ProcessStats {
+                    buf: buf.clone(),
+                    metrics: metrics.clone(),
+                })
+                .await
+            {
+                warn!("couldn't process zdbfs stats: {}", e);
+            }
+        })
+    }
+}
 
 /// An actor implementation of a periodic 0-db-fs statistic getter.
-pub struct ZdbFsStatsActor {
+struct ZdbFsStatsActor {
     stats: Option<ZdbFsStats>,
 }
+
 impl Default for ZdbFsStatsActor {
     fn default() -> Self {
         ZdbFsStatsActor::new()
     }
 }
+
 impl ZdbFsStatsActor {
     /// Create a new ZdbFsStatsActor, which will get statistics and push them to the metrics actor
     /// at a given interval.
-    pub fn new() -> Self {
+    fn new() -> Self {
         ZdbFsStatsActor { stats: None }
     }
-    fn renew_fd(&mut self, path: PathBuf) {
+    fn renew_fd(&mut self, path: PathBuf) -> Result<(), ZstorError> {
         debug!("renewing stats fd");
         let zdbfs_stats = ZdbFsStats::try_new(path)
-            .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats".into(), e));
+            .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats fd".into(), e));
         match zdbfs_stats {
             Ok(v) => {
                 self.stats = Some(v);
+                Ok(())
             }
             Err(e) => {
-                warn!("couldn't get a new zdbbfs stats {}", e);
                 self.stats = None;
+                Err(e)
             }
         }
     }
 }
 
 /// Send stats to the metrics endpoint periodically
-pub struct LoopOverStats {
+struct ProcessStats {
     /// Path buffer to zdbfs mountpoint
-    pub buf: PathBuf,
+    buf: PathBuf,
     /// Metrics actor address
-    pub metrics: Addr<MetricsActor>,
+    metrics: Addr<MetricsActor>,
 }
 
 impl Actor for ZdbFsStatsActor {
     type Context = SyncContext<Self>;
 }
-impl Message for LoopOverStats {
-    type Result = Result<u64, ()>;
+
+impl Message for ProcessStats {
+    type Result = Result<(), ZstorError>;
 }
 
-impl Handler<LoopOverStats> for ZdbFsStatsActor {
-    type Result = Result<u64, ()>;
-    fn handle(&mut self, msg: LoopOverStats, _: &mut Self::Context) -> Self::Result {
-        let rt = Runtime::new().unwrap();
-        loop {
-            match &self.stats {
-                None => self.renew_fd(msg.buf.clone()),
-                Some(stats_obj) => {
-                    let res = stats_obj.get_stats();
-                    let metrics = msg.metrics.clone();
-                    match res {
-                        Err(ref e) => {
-                            warn!("Could not get 0-db-fs stats: {}", e);
-                            self.stats = None;
-                        }
-                        Ok(stats) => {
-                            rt.block_on(async move {
-                                if let Err(e) = metrics.send(UpdateZdbFsStats { stats }).await {
-                                    warn!("Could not update 0-db-fs stats: {}", e);
-                                };
-                            });
-                        }
-                    }
-                }
+impl Handler<ProcessStats> for ZdbFsStatsActor {
+    type Result = Result<(), ZstorError>;
+    fn handle(&mut self, msg: ProcessStats, _: &mut Self::Context) -> Self::Result {
+        if self.stats.is_none() {
+            self.renew_fd(msg.buf.clone())?;
+        }
+        match self
+            .stats
+            .as_ref()
+            .unwrap()
+            .get_stats()
+            .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats".into(), e))
+        {
+            Err(e) => {
+                self.stats = None;
+                Err(e)
             }
-            // would enter runtime work?
-            rt.block_on(async move {
-                sleep(Duration::from_secs(DEFAULT_ZDBFS_STATS_INTERVAL_SECS)).await;
-            });
+            Ok(stats) => {
+                msg.metrics.do_send(UpdateZdbFsStats { stats });
+                Ok(())
+            }
         }
     }
 }

--- a/zstor/src/lib.rs
+++ b/zstor/src/lib.rs
@@ -13,10 +13,10 @@ use crate::actors::{
     explorer::{ExplorerActor, NopExplorerActor},
     meta::MetaStoreActor,
     metrics::{GetPrometheusMetrics, MetricsActor},
-    pipeline::PipelineActor,
+    pipeline::{PipelineActor},
     repairer::RepairActor,
-    zdbfs::ZdbFsStatsActor,
-    zstor::ZstorActor,
+    zdbfs::{ZdbFsStatsActor, LoopOverStats},
+    zstor::{ZstorActor, Check, Retrieve},
 };
 use actix::prelude::*;
 use actix::{Addr, MailboxError};
@@ -24,6 +24,7 @@ use compression::CompressorError;
 use config::ConfigError;
 use encryption::EncryptionError;
 use erasure::EncodingError;
+use path_clean::PathClean;
 use futures::future::try_join_all;
 use grid_explorer_client::{
     identity::{Identity, IdentityError},
@@ -35,13 +36,12 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::task::JoinError;
 use zdb::ZdbError;
-use zdbfs::ZdbFsStats;
 use {
     config::{Config, Encryption, Meta},
     zdb::UserKeyZdb,
     zdb_meta::ZdbMetaStore,
 };
-
+use log::{debug, info, error};
 /// Implementations of all components as actors.
 pub mod actors;
 /// Contains a general compression interface and implementations.
@@ -62,11 +62,14 @@ pub mod zdb_meta;
 /// Zdbfs related tools.
 pub mod zdbfs;
 
+const ZDBFS_META: &str = "zdbfs-meta";
+const ZDBFS_DATA: &str = "zdbfs-data";
+
 /// Global result type for zstor operations
 pub type ZstorResult<T> = Result<T, ZstorError>;
 
 /// Start the 0-stor monitor daemon
-pub async fn setup_system(cfg_path: PathBuf, cfg: Config) -> ZstorResult<Addr<ZstorActor>> {
+pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<Addr<ZstorActor>> {
     let metastore = match cfg.meta() {
         Meta::Zdb(zdb_cfg) => {
             let backends = try_join_all(
@@ -92,9 +95,8 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: Config) -> ZstorResult<Addr<Zs
     let prom_port = cfg.prometheus_port();
     let metrics_addr = MetricsActor::new().start();
     if let Some(mountpoint) = cfg.zdbfs_mountpoint() {
-        let zdbfs_stats = ZdbFsStats::try_new(mountpoint.to_path_buf())
-            .map_err(|e| ZstorError::new_io("Could not get 0-db-fs stats".into(), e))?;
-        let _ = ZdbFsStatsActor::new(zdbfs_stats, metrics_addr.clone()).start();
+        let ad = SyncArbiter::start(1, || ZdbFsStatsActor::new());
+        ad.do_send(LoopOverStats{buf: mountpoint.to_path_buf(), metrics: metrics_addr.clone()});
     }
     let meta_addr = MetaStoreActor::new(metastore).start();
     let cfg_addr = ConfigActor::new(cfg_path, cfg.clone()).start();
@@ -107,6 +109,7 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: Config) -> ZstorResult<Addr<Zs
         metrics_addr.clone(),
     )
     .start();
+    recover_indexes(&cfg, &zstor).await?;
     let _ = DirMonitorActor::new(cfg_addr.clone(), zstor.clone()).start();
 
     let explorer = if let Some(explorer_cfg) = cfg.explorer() {
@@ -149,6 +152,100 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: Config) -> ZstorResult<Addr<Zs
     Ok(zstor)
 }
 
+/// recover index files of the namespaces required by zsbfs
+async fn recover_indexes(cfg: &Config, zstor: &Addr<ZstorActor>) -> ZstorResult<()> {
+
+    // TODO: Should an error here be fatal?
+    if let Err(e) = recover_index(cfg, ZDBFS_META, zstor).await {
+        error!("Could not recover {} index: {}", ZDBFS_META, e);
+        return Err(e);
+    }
+    if let Err(e) = recover_index(cfg, ZDBFS_DATA, zstor).await {
+        error!("Could not recover {} index: {}", ZDBFS_DATA, e);
+        return Err(e);
+    }
+    Ok(())
+}
+/// recover index files of a specific namespace
+pub async fn recover_index(cfg: &Config, ns: &str, zstor: &Addr<ZstorActor>) -> ZstorResult<()> {
+    let mut path = PathBuf::from(cfg.zdb_index_dir_path().unwrap());
+    let mut data_path = PathBuf::from(cfg.zdb_data_dir_path().unwrap());
+    path.push(ns);
+    data_path.push(ns);
+
+    debug!("Attempting to recover index data at {:?}", path);
+
+    // try to recover namespace file
+    let mut namespace_path = path.clone();
+    namespace_path.push("zdb-namespace");
+
+    // TODO: collapse this into separate function and call that
+    if check_file(&namespace_path, &zstor).await? {
+        debug!("namespace file {:?} found in storage, checking local filesystem", namespace_path);
+        // exists on Path is blocking, but it essentially just tests if a `metadata` call
+        // returns ok.
+        if fs::metadata(&namespace_path).await.is_err() {
+            info!("index namespace {:?} file is encoded and not present locally, attempt recovery", namespace_path);
+            // At this point we know that the file is uploaded and not present locally, so an
+            // error here is terminal for the whole recovery process.
+            zstor.send(Retrieve { file: namespace_path }).await??;
+            // create the corresponding data directory
+            fs::create_dir_all(data_path)
+                .await
+                .map_err(|e| ZstorError::new_io("Couldn't create data directory".to_string(), e))?;
+        }
+    }
+
+    // Recover regular index files
+    let mut file_idx = 0usize;
+    loop {
+        let mut index_path = path.clone();
+        index_path.push(format!("i{}", file_idx));
+        if check_file(&index_path, &zstor).await? {
+            debug!("index file {:?} found in storage, checking local filesystem", index_path);
+            // exists on Path is blocking, but it essentially just tests if a `metadata` call
+            // returns ok.
+            if fs::metadata(&index_path).await.is_err() {
+                info!(
+                    "index file {:?} is encoded and not present locally, attempt recovery", index_path
+                );
+                // At this point we know that the file is uploaded and not present locally, so an
+                // error here is terminal for the whole recovery process.
+                zstor.send(Retrieve { file: index_path }).await??;
+            }
+        } else {
+            break;
+        }
+
+        file_idx += 1;
+    }
+
+    Ok(())
+}
+
+/// Return true if the file was deleted
+async fn check_file(path: &Path, zstor: &Addr<ZstorActor>) -> ZstorResult<bool> {
+    let path = PathBuf::from(path).clean();
+    // the Check handler returns an error for missing key
+    // so null checksum and errors are considered for now a missing key error
+    if zstor
+        .send(Check {
+            path: path.clone()
+        })
+        .await?
+        .and_then(|x|
+            x.ok_or(
+                ZstorError::with_message(
+                    ZstorErrorKind::Metadata,
+                    String::from("null checksum")
+                )
+            )
+        )
+        .is_err() {
+        return Ok(false);
+    }
+    return Ok(true);
+}
 /// Load a TOML encoded config file from the given path.
 pub async fn load_config(path: &Path) -> ZstorResult<Config> {
     let cfg_data = fs::read(path)

--- a/zstor/src/main.rs
+++ b/zstor/src/main.rs
@@ -301,7 +301,6 @@ async fn real_main() -> ZstorResult<()> {
             cfg.shard_stores()?;
         }
         Cmd::Monitor => {
-            
             let zstor = zstor_v2::setup_system(opts.config, &cfg).await?;
 
             let server = if let Some(socket) = cfg.socket() {
@@ -316,7 +315,6 @@ async fn real_main() -> ZstorResult<()> {
             // avoid having to clone the whole config.
             let socket_path = cfg.socket().unwrap().to_path_buf();
             let _f = DropFile::new(&socket_path);
-
 
             // setup signal handlers
             let mut sigints = actix_rt::signal::unix::signal(SignalKind::interrupt())

--- a/zstor/src/meta.rs
+++ b/zstor/src/meta.rs
@@ -4,10 +4,10 @@ use crate::zdb::{Key, UserKeyZdb, ZdbConnectionInfo};
 use crate::zdb_meta::ZdbMetaStore;
 use async_trait::async_trait;
 use futures::future::try_join_all;
+use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
-use path_clean::PathClean;
 /// The length of file and shard checksums
 pub const CHECKSUM_LENGTH: usize = 16;
 /// A checksum of a data object


### PR DESCRIPTION
- use path-clean for canonicalizing paths because parent dirs of the file may not exist and causes the the file creation to fail.
- move zstor setup before binding to the socket, so zstor won't start accept connection except after recovering indexes (zstor being ready to accept connection is used in the zinit as a test of readiness)
- move the stats actor into a sync actor to prevent ioctl from blocking the whole thing
- port index recovery from monitor
- the parent dirs of the recovered file is created if it didn't exist
- when recovering indexes, if zdb-namespace is recovered, the corresponding datafiles directory is created (zdb fails if this doesn't happen)
- zdb_index_dir_path is the whole index directory not the `zdbfs-data` index directory, because zdbfs-meta is also considered. Same for zdb_data_dir_path