### PR TITLE
Handle Sigkill signal to not lose in-memory jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,6 +2689,18 @@ dependencies = [
  "arrayvec",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "rustbreak"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460d97902465327d69ecfe8cefdb5972c6f94d6127ac9e992acdb51458bebc27"
+dependencies = [
+ "ron",
+ "serde",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -2936,9 +2959,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3556,6 +3579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,9 +3937,11 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "reed-solomon-erasure",
+ "rustbreak",
  "serde",
  "serde_json",
  "sha-1",
+ "signal-hook",
  "simple_logger",
  "snap",
  "structopt",
@@ -3916,4 +3950,5 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "uuid",
 ]

--- a/zstor/Cargo.toml
+++ b/zstor/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "zstor_v2"
-version = "0.3.0-rc.12"
 authors = ["The Threefold Tech developers <info@threefold.tech>"]
 edition = "2021"
+name = "zstor_v2"
 repository = "https://github.com/threefoldtech/0-stor_v2"
+version = "0.3.0-rc.12"
 
 [[bin]]
 name = "zstor_v2"
@@ -14,50 +14,53 @@ name = "test-zdb"
 path = "src/test_zdb.rs"
 
 [[bench]]
-name = "aes_encryptor"
 harness = false
+name = "aes_encryptor"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 vendored = ["openssl"]
 
 [dependencies]
-reed-solomon-erasure = "4"
-rand = "0.7"
-serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
-hex = "0.4"
-aes-gcm = { version = "0.9", features = ["std"] }
-snap = "1"
-log = { version = "0.4", features = ["release_max_level_debug"] }
-redis = { version = "0.20", default-features = false, features = ["aio", "tokio-comp", "connection-manager"] }
-sha-1 = "0.9"
+actix = "0.12" 
+actix-rt = "2.2" 
+aes-gcm = {version = "0.9", features = ["std"]} 
+async-trait = "0.1" 
+bincode = "1" 
+blake2 = "0.9" 
+chrono = "0.4" 
+futures = "0.3" 
+gray-codes = "0.1" 
+grid_explorer_client = {path = "../grid_explorer_client"} 
+hex = "0.4" 
+log = {version = "0.4", features = ["release_max_level_debug"]} 
+log4rs = {version = "1", default-features = false, features = ["rolling_file_appender", "threshold_filter", "fixed_window_roller", "size_trigger", "compound_policy"]} 
+nix = "0.22" 
+openssl = {version = "0.10", features = ["vendored"], optional = true} 
+path-clean = "0.1.0" 
+pretty_env_logger = "0.4" 
+prometheus = "0.12" 
+rand = "0.7" 
+redis = {version = "0.20", default-features = false, features = ["aio", "tokio-comp", "connection-manager"]} 
+reed-solomon-erasure = "4" 
+rustbreak = {version = "2.0.0", features = ["ron_enc"]} 
+serde = {version = "1.0", features = ["derive"]} 
+serde_json = "1" 
+sha-1 = "0.9" 
+signal-hook = "0.3.14" 
 simple_logger = "1.11" # TODO: remove this
-pretty_env_logger = "0.4"
-structopt = "0.3"
-tokio = { version = "1", features = ["rt", "macros", "fs"] }
-futures = "0.3"
-blake2 = "0.9"
-gray-codes = "0.1"
-log4rs = { version = "1", default-features = false, features = ["rolling_file_appender", "threshold_filter", "fixed_window_roller", "size_trigger", "compound_policy"] }
-async-trait = "0.1"
-bincode = "1"
-openssl = { version = "0.10", features = ["vendored"], optional = true } 
-actix = "0.12"
-actix-rt = "2.2"
-tokio-util = "0.6"
-grid_explorer_client = { path = "../grid_explorer_client" }
-chrono = "0.4"
-serde_json = "1"
-prometheus = "0.12"
-tide = "0.16"
-nix = "0.22"
-path-clean = "0.1.0"
+snap = "1" 
+structopt = "0.3" 
+tide = "0.16" 
+tokio = {version = "1", features = ["rt", "macros", "fs"]} 
+tokio-util = "0.6" 
+toml = "0.5" 
+uuid = {version = "1.1.2", features = ["v4"]} 
 
 [build-dependencies]
 bindgen = "0.59"
 
 [dev-dependencies]
-rand = "0.7"
 criterion = "0.3"
-testutils = { path = "testutils" }
+rand = "0.7"
+testutils = {path = "testutils"}

--- a/zstor/src/actors/zstor.rs
+++ b/zstor/src/actors/zstor.rs
@@ -64,6 +64,21 @@ pub struct Store {
     pub blocking: bool,
 }
 
+/// Store objects can be Saved to the Disk with a DB implements this trait
+pub trait StorePersist {
+    /// Returned Err
+    type Error;
+    /// Insert Store
+    /// Returns store's Id
+    fn insert(&self, store: Store) -> u128;
+    /// Delete Store By the returned Id
+    fn delete(&self, id: u128);
+    /// Return the content into Vector without consuming the handle
+    fn vectored_content(&self,) -> Vec<Store>;
+    /// Persist the content
+    fn save(&self) -> Result<(), Self::Error>;
+}
+
 #[derive(Serialize, Deserialize, Debug, Message, Clone)]
 #[rtype(result = "Result<(), ZstorError>")]
 /// Message for the retrieve command of zstor.

--- a/zstor/tests/integration_test.rs
+++ b/zstor/tests/integration_test.rs
@@ -146,7 +146,7 @@ fn retrieves_more_prior_than_stores() {
     // it issues a retrieve command. this command should be handled before
     // the rest of the stores. this is because the zdb file system blocks on it
     let mut manager = TestManager::new(TestParams {
-        id: "rmpts".to_string(),
+        id: "zse".to_string(),
         network_speed: None,
         max_zdb_data_dir_size: None,
         data_disk_size: "20G".into(),


### PR DESCRIPTION
- create StorePersist Trait
- implement StorePersist Trait for StoreDb
- add a new instance of db to zstorescheduler
- make the old stores get into the store's cycle
- handle the sigkill signal