### PR TITLE
Fix github integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,13 +28,21 @@ jobs:
     # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
     # change behavior.
     - name: Install 0-db
-      run: sudo wget -O /usr/bin/zdb https://github.com/threefoldtech/0-db/releases/download/v2.0.4/zdb-2.0.4-linux-amd64-static
+      run: |
+        sudo wget -O /usr/bin/zdb https://github.com/threefoldtech/0-db/releases/download/v2.0.4/zdb-2.0.4-linux-amd64-static
+        sudo chmod +x /usr/bin/zdb
     - name: Install 0-db hook script
-      run: wget -O hook.sh https://raw.githubusercontent.com/threefoldtech/quantum-storage/v0.1.0/lib/zdb-hook.sh
+      run: |
+        wget -O hook.sh https://raw.githubusercontent.com/threefoldtech/quantum-storage/v0.1.0/lib/zdb-hook.sh
+        chmod +x hook.sh
     - name: Install 0-db-fs
-      run: sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
+      run: |
+        sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
+        sudo chmod +x /usr/bin/zdbfs
     - name: Install wondershaper
-      run: sudo wget -O /usr/bin/wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
+      run: |
+        sudo wget -O /usr/bin/wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
+        sudo chmod +x /usr/bin/wondershaper
     - name: Build tests
       run: cargo build --tests
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,16 +11,19 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - name: Run tests
       run: cargo test --verbose
-          
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install redis
+    - name: Install redis-cli | nc
       run: |
         sudo apt update
-        sudo apt install -y redis
+        sudo apt install -y redis-tools netcat
     # We download specific versions here. The versions themselves don't really matter, but since the aim here is to have tests for 0-stor,
     # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
     # change behavior.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
     # We download specific versions here. The versions themselves don't really matter, but since the aim here is to have tests for 0-stor,
     # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
     # change behavior.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build tests
       run: cargo build --tests
     - name: Run tests
-      run: sudo exec $(find target/debug/deps/integration_test-* -type f -executable -print)
+      run: find target/debug/deps/integration_test-* -type f -executable -print | xargs sudo
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build tests
       run: cargo build --tests
     - name: Run tests
-      run: sudo target/debug/deps/integration_test-*([a-f0-9])
+      run: sudo exec $(find target/debug/deps/integration_test-* -type f -executable -print)
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install 0-db-fs
       run: sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
     - name: Install wondershaper
-      run: sudo wget -O wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
+      run: sudo wget -O /usr/bin/wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
     - name: Build tests
       run: cargo build --tests
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,17 +35,10 @@ jobs:
       run: sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
     - name: Install wondershaper
       run: sudo wget -O wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
-    # Giving a path to the user directory is not a good flow, but invoking cargo with sudo is not available. And there is not a trivial
-    # action.
-    # Also, we need to set up rust specifically for the root user
-    - name: Setup rust on root
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo sh -s -- -y
-        sudo source "$HOME/.cargo/env"
-        sudo rustup toolchain install stable
-        sudo rustup default stable
+    - name: Build tests
+      run: cargo build --tests
     - name: Run tests
-      run: sudo /home/runner/.cargo/bin/cargo test --verbose
+      run: sudo target/debug/deps/integration_test-*([a-f0-9])
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # We download specific versions here. The versions themselves don't really matter, but since the aim here is to have tests for 0-stor,
+    # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
+    # change behavior.
+    - name: Install 0-db
+      run: sudo wget -O /usr/bin/zdb https://github.com/threefoldtech/0-db/releases/download/v2.0.4/zdb-2.0.4-linux-amd64-static
+    - name: Install 0-db hook script
+      run: wget -O hook.sh https://raw.githubusercontent.com/threefoldtech/quantum-storage/v0.1.0/lib/zdb-hook.sh
+    - name: Install 0-db-fs
+      run: sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
+    - name: Install wondershaper
+      run: sudo wget -O wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
     - name: Run tests
-      run: cargo test --verbose
+      run: sudo cargo test --verbose
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install redis
+      run: |
+        sudo apt update
+        sudo apt install -y redis
     # We download specific versions here. The versions themselves don't really matter, but since the aim here is to have tests for 0-stor,
     # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
     # change behavior.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     # We download specific versions here. The versions themselves don't really matter, but since the aim here is to have tests for 0-stor,
     # instead of the full qsfs stack, we avoid using latest, as that could introduce test failure because the components used in the tests
     # change behavior.
@@ -32,8 +35,17 @@ jobs:
       run: sudo wget -O /usr/bin/zdbfs https://github.com/threefoldtech/0-db-fs/releases/download/v0.1.10/zdbfs-0.1.10-amd64-linux-static
     - name: Install wondershaper
       run: sudo wget -O wondershaper https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper
+    # Giving a path to the user directory is not a good flow, but invoking cargo with sudo is not available. And there is not a trivial
+    # action.
+    # Also, we need to set up rust specifically for the root user
+    - name: Setup rust on root
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo sh -s -- -y
+        sudo source "$HOME/.cargo/env"
+        sudo rustup toolchain install stable
+        sudo rustup default stable
     - name: Run tests
-      run: sudo cargo test --verbose
+      run: sudo /home/runner/.cargo/bin/cargo test --verbose
 
   fmt:
     name: Rustfmt

--- a/zstor/tests/readme.md
+++ b/zstor/tests/readme.md
@@ -3,11 +3,14 @@
 These tests test zdbfs+zdb+zstor setup.
 
 It requires having:
+
 - `/usr/local/bin/hook.sh` with the hook file
 - zstor, zdb, zdbfs binaries
 - [wondershaper](https://github.com/magnific0/wondershaper/blob/master/wondershaper)
+- redis-cli
 
 It runs as root.
 
 ## Running tests
+
 `cargo test --test integration_test -- --nocapture`

--- a/zstor/testutils/src/disk.rs
+++ b/zstor/testutils/src/disk.rs
@@ -44,8 +44,8 @@ impl Disk {
 
     pub fn delete(&mut self) -> Result<()> {
         if let Some(ref image_path) = self.image {
-            let mut cmd = Command::new("sudo");
-            cmd.arg("umount").arg(&self.path);
+            let mut cmd = Command::new("umount");
+            cmd.arg(&self.path);
             exec(cmd)?;
             let mut cmd = Command::new("rm");
             cmd.arg("-rf").arg(&self.path);

--- a/zstor/testutils/src/netns.rs
+++ b/zstor/testutils/src/netns.rs
@@ -28,7 +28,8 @@ impl Netns {
 
     pub fn delete(&self) -> Result<()> {
         println!("deleting {}", self.name);
-        Command::new("ip")
+        Command::new("sudo")
+            .arg("ip")
             .arg("netns")
             .arg("del")
             .arg(&self.name)
@@ -37,7 +38,8 @@ impl Netns {
     }
 
     pub fn own(&self, name: String) -> Result<()> {
-        Command::new("ip")
+        Command::new("sudo")
+            .arg("ip")
             .arg("link")
             .arg("set")
             .arg(&name)
@@ -49,8 +51,9 @@ impl Netns {
 
     pub fn wrap(&self, cmd: Command) -> Command {
         let name = cmd.get_program().to_str().unwrap();
-        let mut res = Command::new("ip");
-        res.arg("netns")
+        let mut res = Command::new("sudo");
+        res.arg("ip")
+            .arg("netns")
             .arg("exec")
             .arg(&self.name)
             .arg(name)

--- a/zstor/testutils/src/netns.rs
+++ b/zstor/testutils/src/netns.rs
@@ -16,8 +16,8 @@ impl Netns {
 
     pub fn create(&self) -> Result<()> {
         println!("creating {}", self.name);
-        let mut cmd = Command::new("sudo");
-        cmd.arg("ip").arg("netns").arg("add").arg(&self.name);
+        let mut cmd = Command::new("ip");
+        cmd.arg("netns").arg("add").arg(&self.name);
         exec(cmd)?;
         let mut cmd = Command::new("ip");
         cmd.arg("link").arg("set").arg("lo").arg("up");
@@ -28,8 +28,7 @@ impl Netns {
 
     pub fn delete(&self) -> Result<()> {
         println!("deleting {}", self.name);
-        Command::new("sudo")
-            .arg("ip")
+        Command::new("ip")
             .arg("netns")
             .arg("del")
             .arg(&self.name)
@@ -38,8 +37,7 @@ impl Netns {
     }
 
     pub fn own(&self, name: String) -> Result<()> {
-        Command::new("sudo")
-            .arg("ip")
+        Command::new("ip")
             .arg("link")
             .arg("set")
             .arg(&name)
@@ -51,9 +49,8 @@ impl Netns {
 
     pub fn wrap(&self, cmd: Command) -> Command {
         let name = cmd.get_program().to_str().unwrap();
-        let mut res = Command::new("sudo");
-        res.arg("ip")
-            .arg("netns")
+        let mut res = Command::new("ip");
+        res.arg("netns")
             .arg("exec")
             .arg(&self.name)
             .arg(name)

--- a/zstor/testutils/src/utils.rs
+++ b/zstor/testutils/src/utils.rs
@@ -18,8 +18,8 @@ pub fn exec(mut cmd: Command) -> Result<String> {
     let stdout: String = str::from_utf8(&out.stdout)?.into();
     let stderr = str::from_utf8(&out.stderr)?;
     if !out.status.success() {
-        println!("stderr: {}", stdout);
-        println!("stdout: {}", stderr);
+        println!("stdout: {}", stdout);
+        println!("stderr: {}", stderr);
         return Err(anyhow!(
             "failed to execute with error {}: \nstderr: {}\nstdout: {}",
             out.status,

--- a/zstor/testutils/src/utils.rs
+++ b/zstor/testutils/src/utils.rs
@@ -171,9 +171,8 @@ pub fn tempdir() -> String {
 }
 
 pub fn sed(path: &Path, src: &str, dst: &str) {
-    let mut cmd = Command::new("sudo");
-    cmd.arg("sed")
-        .arg("-i")
+    let mut cmd = Command::new("sed");
+    cmd.arg("-i")
         .arg(format!("s/{}/{}/g", src, dst))
         .arg(path.to_str().unwrap());
     exec(cmd).expect("replacing in file");

--- a/zstor/testutils/src/veth.rs
+++ b/zstor/testutils/src/veth.rs
@@ -17,9 +17,8 @@ impl Veth {
         netns2: Option<&Netns>,
         network_speed: Option<u32>,
     ) -> Result<(Veth, Veth)> {
-        let mut cmd = Command::new("sudo");
-        cmd.arg("ip")
-            .arg("link")
+        let mut cmd = Command::new("ip");
+        cmd.arg("link")
             .arg("add")
             .arg(name1)
             .arg("type")
@@ -59,12 +58,8 @@ impl Veth {
         Ok(())
     }
     pub fn set_up(&mut self) -> Result<()> {
-        let mut cmd = Command::new("sudo");
-        cmd.arg("ip")
-            .arg("link")
-            .arg("set")
-            .arg(&self.name)
-            .arg("up");
+        let mut cmd = Command::new("ip");
+        cmd.arg("link").arg("set").arg(&self.name).arg("up");
         if let Some(ns) = &self.namespace {
             cmd = ns.wrap(cmd);
         }
@@ -72,9 +67,8 @@ impl Veth {
         Ok(())
     }
     pub fn set_addr(&mut self, addr: String) -> Result<()> {
-        let mut cmd = Command::new("sudo");
-        cmd.arg("ip")
-            .arg("addr")
+        let mut cmd = Command::new("p");
+        cmd.arg("addr")
             .arg("add")
             .arg(&addr)
             .arg("dev")
@@ -87,8 +81,8 @@ impl Veth {
     }
 
     pub fn delete(&mut self) -> Result<()> {
-        let mut cmd = Command::new("sudo");
-        cmd.arg("ip").arg("link").arg("del").arg(&self.name);
+        let mut cmd = Command::new("ip");
+        cmd.arg("link").arg("del").arg(&self.name);
         if let Some(ns) = &self.namespace {
             cmd = ns.wrap(cmd);
         }
@@ -109,8 +103,8 @@ impl Veth {
     }
 
     pub fn clear_limits(&self) -> Result<()> {
-        let mut cmd = Command::new("sudo");
-        cmd.arg("wondershaper").arg("-a").arg(&self.name).arg("-c");
+        let mut cmd = Command::new("wondershaper");
+        cmd.arg("-a").arg(&self.name).arg("-c");
         exec(cmd)?;
         Ok(())
     }

--- a/zstor/testutils/src/veth.rs
+++ b/zstor/testutils/src/veth.rs
@@ -67,7 +67,7 @@ impl Veth {
         Ok(())
     }
     pub fn set_addr(&mut self, addr: String) -> Result<()> {
-        let mut cmd = Command::new("p");
+        let mut cmd = Command::new("ip");
         cmd.arg("addr")
             .arg("add")
             .arg(&addr)


### PR DESCRIPTION
Netns operations generally require privileged mode, whereas github actions linux runners run non-privileged but with passwordless sudo available.