### PR TITLE
fix(meta): refresh metastore if there is zdb up/down

### DIFF
--- a/zstor/src/actors/meta.rs
+++ b/zstor/src/actors/meta.rs
@@ -106,6 +106,9 @@ pub struct MarkWriteable {
 pub struct ReplaceMetaStore {
     /// The new metastore to set
     pub new_store: Box<dyn MetaStore + Send>,
+
+    /// writeable flag
+    pub writeable: bool,
 }
 
 /// Actor for a metastore
@@ -272,6 +275,8 @@ impl Handler<ReplaceMetaStore> for MetaStoreActor {
     type Result = ();
 
     fn handle(&mut self, msg: ReplaceMetaStore, _: &mut Self::Context) -> Self::Result {
+        log::info!("ReplaceMetaStore writeable: {}", msg.writeable);
         self.meta_store = Arc::from(msg.new_store as Box<dyn MetaStore>);
+        self.writeable = msg.writeable;
     }
 }

--- a/zstor/src/zdb.rs
+++ b/zstor/src/zdb.rs
@@ -806,7 +806,7 @@ impl UserKeyZdb {
 }
 
 /// Information about a 0-db namespace, as reported by the db itself.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NsInfo {
     /// The name of the namespace.
     pub name: String,


### PR DESCRIPTION
part of #127 : 
> when the meta backend up, zstor monitor automatically reconnect to that backend