### PR TITLE
fix(dedup rebuild): if possible, use same backend during rebuild

### DIFF
--- a/zstor/src/actors/zstor.rs
+++ b/zstor/src/actors/zstor.rs
@@ -340,13 +340,11 @@ impl Handler<Rebuild> for ZstorActor {
                     if let Some(data) = data {
                         if data.as_slice() == shards[i].as_ref() {
                             used_backends.push((key, Some(old_metadata.shards()[i].zdb().clone())));
-                            debug!("Shard {} is the SAME", i);
                         } else {
                             used_backends.push((key, None));
-                            warn!("Shard {} is DIFFERENT", i);
+                            error!("Shard {} is DIFFERENT", i);
                         }
                     } else {
-                        debug!("Shard {} is MISSING", i);
                         used_backends.push((key, None));
                     }
                 }


### PR DESCRIPTION
Changes:
- use previous backends if still alive
- Only set the data on the new backends.

Fixes #5 