### PR TITLE
reuse metadata when rebuilding the data.

### DIFF
--- a/zstor/src/actors/repairer.rs
+++ b/zstor/src/actors/repairer.rs
@@ -125,6 +125,7 @@ impl Handler<SweepObjects> for RepairActor {
                             .send(Rebuild {
                                 file: None,
                                 key: Some(key),
+                                metadata: Some(metadata),
                             })
                             .await
                         {

--- a/zstor/src/main.rs
+++ b/zstor/src/main.rs
@@ -311,7 +311,15 @@ async fn real_main() -> ZstorResult<()> {
             handle_command(ZstorCommand::Retrieve(Retrieve { file }), opts.config).await?
         }
         Cmd::Rebuild { file, key } => {
-            handle_command(ZstorCommand::Rebuild(Rebuild { file, key }), opts.config).await?
+            handle_command(
+                ZstorCommand::Rebuild(Rebuild {
+                    file,
+                    key,
+                    metadata: None,
+                }),
+                opts.config,
+            )
+            .await?
         }
         Cmd::Check { file } => {
             handle_command(ZstorCommand::Check(Check { path: file }), opts.config).await?


### PR DESCRIPTION
SweepObject already have the metadata of the data, we can reuse it for data rebuild instead of fetch the metadata again