### PR TITLE
Make data dir cache eviction work and fail loudly

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ password = "supersecretpass"
     then be exposed through the build-in prometheus server.
 - `prometheus_port`: An optional port on which prometheus metrics will be
     exposed. If this is not set, the metrics will not get exposed.
+- `unattended_repair`: Whether the monitor repairs degraded objects on its
+    own. If `true` (the default), the monitor periodically scans all stored
+    objects and rebuilds those with shards on unreachable backends. If
+    `false`, scans only run when explicitly requested through the `sweep`
+    command, so repair scheduling can be owned by an external system.
+- `repair_interval_secs`: Time in seconds between automatic repair scans of
+    all stored objects. Only relevant when unattended repair is enabled.
+    Defaults to 600 seconds.
+- `missing_backend_grace_secs`: Time in seconds a backend can be unreachable
+    before it is considered gone, making its shards eligible for repair and
+    the backend itself eligible for replacement. Defaults to 900 seconds.
 - `encryption`: configuration to use for the encryption stage. Currently
     only `AES` is supported. The encryption `key` is 32 random bytes in hexadecimal form.
 - `compression`: configuration to use for the compression stage.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ password = "supersecretpass"
 - `missing_backend_grace_secs`: Time in seconds a backend can be unreachable
     before it is considered gone, making its shards eligible for repair and
     the backend itself eligible for replacement. Defaults to 900 seconds.
+- `degraded_write_margin`: The amount of shards which must be placed on top
+    of `minimal_shards` for a write to be accepted when not all
+    `expected_shards` can be placed (because backends are unreachable or
+    full). Writes always place all expected shards when possible; this margin
+    only bounds how far a write may degrade before it is refused, and the
+    repair sweep backfills the missing shards once capacity returns. Defaults
+    to 1, so a freshly written object always survives at least one further
+    backend loss. Set it to `expected_shards - minimal_shards` to refuse any
+    degraded write.
 - `encryption`: configuration to use for the encryption stage. Currently
     only `AES` is supported. The encryption `key` is 32 random bytes in hexadecimal form.
 - `compression`: configuration to use for the compression stage.

--- a/zstor/src/actors/backends.rs
+++ b/zstor/src/actors/backends.rs
@@ -774,7 +774,7 @@ impl Handler<ReplaceBackends> for BackendManagerActor {
 
 /// IntermediateRequestState for resolving cached connections
 enum IrState {
-    Cached((SequentialZdb, BackendState)),
+    Cached(Box<(SequentialZdb, BackendState)>),
     NotFound(ZdbConnectionInfo),
 }
 impl Handler<RequestBackends> for BackendManagerActor {
@@ -785,7 +785,7 @@ impl Handler<RequestBackends> for BackendManagerActor {
         for request in &msg.backend_requests {
             let cached_con = if let Some((c, state)) = self.managed_seq_dbs.get(request) {
                 match c {
-                    Some(con) => IrState::Cached((con.clone(), state.clone())),
+                    Some(con) => IrState::Cached(Box::new((con.clone(), state.clone()))),
                     // None means there is no readily available connection to the backend, so create a
                     // new one. This means state is not healthy anyway.
                     None => IrState::NotFound(request.clone()),
@@ -799,7 +799,8 @@ impl Handler<RequestBackends> for BackendManagerActor {
         Box::pin(async move {
             let interest = msg.interest;
             let futs = cached_cons.into_iter().map(|mut cc| async move {
-                if let IrState::Cached((con, state)) = cc {
+                if let IrState::Cached(cached) = cc {
+                    let (con, state) = *cached;
                     match interest {
                         StateInterest::Writeable if state.is_writeable() => return Ok(Some(con)),
                         StateInterest::Readable if state.is_readable() => return Ok(Some(con)),

--- a/zstor/src/actors/backends.rs
+++ b/zstor/src/actors/backends.rs
@@ -22,9 +22,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// Amount of time a backend can be unreachable before it is actually considered unreachable.
-/// Currently set to 15 minutes.
-const MISSING_DURATION: Duration = Duration::from_secs(15 * 60);
 /// The amount of free space left in a backend before it is considered to be full. Currently this is
 /// 100 MiB.
 const FREESPACE_TRESHOLD: u64 = 100 * (1 << 20);
@@ -43,15 +40,18 @@ pub struct BackendManagerActor {
     metastore: Addr<MetaStoreActor>,
     managed_seq_dbs: HashMap<ZdbConnectionInfo, (Option<SequentialZdb>, BackendState)>,
     managed_meta_dbs: HashMap<ZdbConnectionInfo, (Option<UserKeyZdb>, BackendState)>,
+    missing_grace: Duration,
 }
 
 impl BackendManagerActor {
-    /// Create a new [`BackendManagerActor`].
+    /// Create a new [`BackendManagerActor`]. The `missing_grace` duration controls how long a
+    /// backend can be unreachable before it is considered gone.
     pub fn new(
         config_addr: Addr<ConfigActor>,
         explorer: Recipient<ExpandStorage>,
         metrics: Addr<MetricsActor>,
         metastore: Addr<MetaStoreActor>,
+        missing_grace: Duration,
     ) -> BackendManagerActor {
         Self {
             config_addr,
@@ -60,6 +60,7 @@ impl BackendManagerActor {
             metastore,
             managed_seq_dbs: HashMap::new(),
             managed_meta_dbs: HashMap::new(),
+            missing_grace,
         }
     }
 
@@ -233,10 +234,17 @@ impl Handler<ReloadConfig> for BackendManagerActor {
             async move {
                 let (managed_seq_dbs, managed_meta_dbs) =
                     get_zdbs_from_config(cfg_addr.clone()).await;
-                (managed_seq_dbs, managed_meta_dbs)
+                let grace = match cfg_addr.send(GetConfig).await {
+                    Ok(cfg) => Some(cfg.missing_backend_grace()),
+                    Err(_) => None,
+                };
+                (managed_seq_dbs, managed_meta_dbs, grace)
             }
             .into_actor(self)
-            .map(move |(seq_dbs, meta_dbs), actor, _| {
+            .map(move |(seq_dbs, meta_dbs, grace), actor, _| {
+                if let Some(grace) = grace {
+                    actor.missing_grace = grace;
+                }
                 // remove the data backends that are no longer managed from  the metrics
                 for (ci, _) in actor.managed_seq_dbs.iter() {
                     if !seq_dbs.contains_key(ci) {
@@ -386,6 +394,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
             .collect::<Vec<_>>();
 
         let actor_addr = ctx.address();
+        let grace = self.missing_grace;
         Box::pin(
             async move {
                 let futs = data_backend_info
@@ -395,7 +404,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                             let info = match db.ns_info().await {
                                 Err(e) => {
                                     warn!("Failed to get ns_info from {}: {}", ci, e);
-                                    state.mark_unreachable();
+                                    state.mark_unreachable(grace);
                                     None
                                 }
                                 Ok(info) => {
@@ -410,7 +419,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                                 let info = match db.ns_info().await {
                                     Err(e) => {
                                         warn!("Failed to get ns_info from {}: {}", ci, e);
-                                        state.mark_unreachable();
+                                        state.mark_unreachable(grace);
                                         None
                                     }
                                     Ok(info) => {
@@ -420,7 +429,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                                 };
                                 (ci, Some(db), state, info)
                             } else {
-                                state.mark_unreachable();
+                                state.mark_unreachable(grace);
                                 (ci, None, state, None)
                             }
                         }
@@ -433,7 +442,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                             let info = match db.ns_info().await {
                                 Err(e) => {
                                     warn!("Failed to get ns_info from {}: {}", ci, e);
-                                    state.mark_unreachable();
+                                    state.mark_unreachable(grace);
                                     None
                                 }
                                 Ok(info) => {
@@ -448,7 +457,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                                 let info = match db.ns_info().await {
                                     Err(e) => {
                                         warn!("Failed to get ns_info from {}: {}", ci, e);
-                                        state.mark_unreachable();
+                                        state.mark_unreachable(grace);
                                         None
                                     }
                                     Ok(info) => {
@@ -458,7 +467,7 @@ impl Handler<CheckBackends> for BackendManagerActor {
                                 };
                                 (ci, Some(db), state, info)
                             } else {
-                                state.mark_unreachable();
+                                state.mark_unreachable(grace);
                                 (ci, None, state, None)
                             }
                         }
@@ -560,6 +569,7 @@ impl Handler<ReplaceBackends> for BackendManagerActor {
     fn handle(&mut self, _: ReplaceBackends, _: &mut Self::Context) -> Self::Result {
         debug!("Attempting to replace backends");
         let explorer = self.explorer.clone();
+        let grace = self.missing_grace;
         // Grab all backends which must be replaced.
         let seq_replacements = self
             .managed_seq_dbs
@@ -587,7 +597,7 @@ impl Handler<ReplaceBackends> for BackendManagerActor {
             .into_iter()
             .map(|(ci, state)| {
                 let explorer = explorer.clone();
-                get_seq_zdb(explorer, ci, state)
+                get_seq_zdb(explorer, ci, state, grace)
             })
             .collect::<Vec<_>>();
 
@@ -607,7 +617,7 @@ impl Handler<ReplaceBackends> for BackendManagerActor {
             // Finally, request new 0-dbs and decommission unreadable ones.
             .map(|(ci, state)| {
                 let explorer = explorer.clone();
-                get_user_zdb(explorer, ci, state)
+                get_user_zdb(explorer, ci, state, grace)
             })
             .collect::<Vec<_>>();
 
@@ -837,6 +847,7 @@ async fn get_seq_zdb(
     explorer: Recipient<ExpandStorage>,
     ci: ZdbConnectionInfo,
     state: BackendState,
+    grace: Duration,
 ) -> Result<(ZdbConnectionInfo, Option<SequentialZdb>, BackendState), ZstorError> {
     let res = explorer
         .send(ExpandStorage {
@@ -859,7 +870,7 @@ async fn get_seq_zdb(
         Ok(db) => {
             match db.ns_info().await {
                 Ok(info) => state.mark_healthy(info.free_space()),
-                Err(_) => state.mark_unreachable(),
+                Err(_) => state.mark_unreachable(grace),
             };
             Ok((res, Some(db), state))
         }
@@ -876,6 +887,7 @@ async fn get_user_zdb(
     explorer: Recipient<ExpandStorage>,
     ci: ZdbConnectionInfo,
     state: BackendState,
+    grace: Duration,
 ) -> Result<(ZdbConnectionInfo, Option<UserKeyZdb>, BackendState), ZstorError> {
     let res = explorer
         .send(ExpandStorage {
@@ -899,7 +911,7 @@ async fn get_user_zdb(
         Ok(db) => {
             match db.ns_info().await {
                 Ok(info) => state.mark_healthy(info.free_space()),
-                Err(_) => state.mark_unreachable(),
+                Err(_) => state.mark_unreachable(grace),
             };
             Ok((res, Some(db), state))
         }
@@ -945,15 +957,16 @@ impl BackendState {
     }
 
     /// Indicate that the backend is (currently) unreachable. Depending on the previous state, this
-    /// might change the state.
-    pub fn mark_unreachable(&mut self) {
+    /// might change the state. The `grace` duration controls how long a backend can remain
+    /// unreachable before it is considered gone.
+    pub fn mark_unreachable(&mut self, grace: Duration) {
         match self {
             BackendState::Unreachable => {}
-            BackendState::Unknown(since) if since.elapsed() >= MISSING_DURATION => {
+            BackendState::Unknown(since) if since.elapsed() >= grace => {
                 debug!("Backend state changed to unreachable");
                 *self = BackendState::Unreachable;
             }
-            BackendState::Unknown(since) if since.elapsed() < MISSING_DURATION => (),
+            BackendState::Unknown(since) if since.elapsed() < grace => (),
             _ => *self = BackendState::Unknown(Instant::now()),
         }
     }

--- a/zstor/src/actors/config.rs
+++ b/zstor/src/actors/config.rs
@@ -71,6 +71,9 @@ impl Handler<GetConfig> for ConfigActor {
 impl Handler<ReloadConfig> for ConfigActor {
     type Result = AtomicResponse<Self, Result<(), ZstorError>>;
 
+    // The intermediate result carries ZstorError, which clippy considers large; boxing it is
+    // a crate-wide refactor out of scope here, and the same lint is already allowed elsewhere.
+    #[allow(clippy::result_large_err)]
     fn handle(&mut self, _: ReloadConfig, _: &mut Self::Context) -> Self::Result {
         let path = self.config_path.clone();
         debug!("Config actor reloading running config from {:?}", path);

--- a/zstor/src/actors/dir_monitor.rs
+++ b/zstor/src/actors/dir_monitor.rs
@@ -167,10 +167,7 @@ async fn attempt_removal(path: &Path, zstor: Addr<ZstorActor>) -> ZstorResult<bo
     let path = fs::canonicalize(path).await.map_err(|e| {
         ZstorError::new_io(
             "Could not canonicalize path".into(),
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Could not canonicalize path: {}", e),
-            ),
+            io::Error::other(format!("Could not canonicalize path: {}", e)),
         )
     })?;
     if zstor.send(Check { path: path.clone() }).await??.is_none() {
@@ -180,11 +177,8 @@ async fn attempt_removal(path: &Path, zstor: Addr<ZstorActor>) -> ZstorResult<bo
     // file is uploaded
     fs::remove_file(&path).await.map(|_| true).map_err(|e| {
         ZstorError::new_io(
-            "Could not canonicalize path".into(),
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Could not canonicalize path: {}", e),
-            ),
+            "Could not remove file".into(),
+            io::Error::other(format!("Could not remove file: {}", e)),
         )
     })
 }

--- a/zstor/src/actors/dir_monitor.rs
+++ b/zstor/src/actors/dir_monitor.rs
@@ -1,19 +1,24 @@
 use crate::actors::{
     config::{ConfigActor, GetConfig},
+    metrics::{MetricsActor, SetDataDirStats},
     zstor::{Check, ZstorActor},
 };
+use crate::meta::{Checksum, CHECKSUM_LENGTH};
 use crate::{ZstorError, ZstorResult};
 use actix::prelude::*;
+use blake2::{
+    digest::{Update, VariableOutput},
+    Blake2bVar,
+};
 use log::{debug, error, info, warn};
 use std::{
     fs::Metadata,
     path::{Path, PathBuf},
     time::Duration,
 };
+use tokio::io::AsyncReadExt;
 use tokio::{fs, io};
 
-/// Amount of seconds between every [`CheckDir`] command.
-const DIR_MONITOR_INTERVAL_SECONDS: u64 = 60;
 /// 1 MiB.
 const MIB: u64 = 1 << 20;
 
@@ -21,6 +26,8 @@ const MIB: u64 = 1 << 20;
 pub struct DirMonitorActor {
     cfg: Addr<ConfigActor>,
     zstor: Addr<ZstorActor>,
+    metrics: Addr<MetricsActor>,
+    interval: Duration,
 }
 
 /// Message requesting the actor to reduce the watched directory to the size limit.
@@ -28,21 +35,42 @@ pub struct DirMonitorActor {
 #[rtype(result = "()")]
 struct CheckDir;
 
+/// The result of a single eviction attempt.
+enum RemovalOutcome {
+    /// The file was evicted.
+    Removed,
+    /// The file must stay, with the reason why.
+    Kept(&'static str),
+    /// The file disappeared while it was being checked, so there is nothing left to evict.
+    Vanished,
+}
+
 impl Actor for DirMonitorActor {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(
-            Duration::from_secs(DIR_MONITOR_INTERVAL_SECONDS),
-            Self::check_dir,
-        );
+        // Check immediately at startup: if the daemon comes (back) up under disk pressure,
+        // eviction should not wait a full interval before reacting.
+        ctx.notify(CheckDir);
+        ctx.run_interval(self.interval, Self::check_dir);
     }
 }
 
 impl DirMonitorActor {
-    /// Create a new [`DirMonitorActor`] using the given [`ConfigActor`] and [`ZstorActor`].
-    pub fn new(cfg: Addr<ConfigActor>, zstor: Addr<ZstorActor>) -> DirMonitorActor {
-        Self { cfg, zstor }
+    /// Create a new [`DirMonitorActor`] using the given [`ConfigActor`], [`ZstorActor`] and
+    /// [`MetricsActor`], checking the directory on the given interval.
+    pub fn new(
+        cfg: Addr<ConfigActor>,
+        zstor: Addr<ZstorActor>,
+        metrics: Addr<MetricsActor>,
+        interval: Duration,
+    ) -> DirMonitorActor {
+        Self {
+            cfg,
+            zstor,
+            metrics,
+            interval,
+        }
     }
 
     /// Trigger the directory check action.
@@ -57,6 +85,7 @@ impl Handler<CheckDir> for DirMonitorActor {
     fn handle(&mut self, _: CheckDir, _: &mut Self::Context) -> Self::Result {
         let cfg_addr = self.cfg.clone();
         let zstor = self.zstor.clone();
+        let metrics = self.metrics.clone();
         Box::pin(async move {
             let cfg = match cfg_addr.send(GetConfig).await {
                 Err(e) => {
@@ -90,6 +119,12 @@ impl Handler<CheckDir> for DirMonitorActor {
                     "Directory {:?} is within size limits ({} < {})",
                     dir_path, dir_size, size_limit
                 );
+                metrics.do_send(SetDataDirStats {
+                    size_bytes: dir_size,
+                    limit_bytes: size_limit,
+                    evicted: 0,
+                    failures: 0,
+                });
                 return;
             }
 
@@ -103,39 +138,57 @@ impl Handler<CheckDir> for DirMonitorActor {
                 meta_1.accessed().unwrap().cmp(&meta_2.accessed().unwrap())
             });
 
+            let mut evicted: u64 = 0;
+            let mut kept: u64 = 0;
+            let mut failures: u64 = 0;
             for (path, meta) in entries {
+                if dir_size < size_limit {
+                    break;
+                }
                 debug!(
                     "Attempt to delete file {:?} (size: {}, last accessed: {:?})",
                     path,
                     meta.len(),
                     meta.accessed().unwrap()
                 );
-                let removed = match attempt_removal(&path, zstor.clone()).await {
-                    Ok(removed) => removed,
-                    Err(e) => {
-                        error!("Could not remove file: {}", e);
-                        return;
+                match attempt_removal(&path, zstor.clone()).await {
+                    Ok(RemovalOutcome::Removed) => {
+                        evicted += 1;
+                        dir_size = dir_size.saturating_sub(meta.len());
                     }
-                };
-                if removed {
-                    dir_size -= meta.len();
-                    if dir_size < size_limit {
-                        return;
+                    // The file is gone, so it no longer takes up space in the dir.
+                    Ok(RemovalOutcome::Vanished) => {
+                        dir_size = dir_size.saturating_sub(meta.len());
+                    }
+                    Ok(RemovalOutcome::Kept(reason)) => {
+                        kept += 1;
+                        debug!("Keeping file {:?}: {}", path, reason);
+                    }
+                    // A failure on one file must not starve the rest of the pass.
+                    Err(e) => {
+                        failures += 1;
+                        error!("Could not evict file {:?}: {}", path, e);
                     }
                 }
             }
 
             if dir_size < size_limit {
                 info!(
-                    "Sufficiently reduced data dir ({:?}) size (new size: {})",
-                    dir_path, dir_size
+                    "Sufficiently reduced data dir ({:?}) size (new size: {}, {} files evicted)",
+                    dir_path, dir_size, evicted
                 );
             } else {
                 warn!(
-                    "Failed to reduce dir ({:?}) size to acceptable limit (currently {})",
-                    dir_path, dir_size
+                    "Data dir ({:?}) is still over its size limit after an eviction pass ({} >= {}): {} evicted, {} kept (not or not verifiably dispersed), {} failed — the disk will keep filling unless dispersal catches up or the limit is raised",
+                    dir_path, dir_size, size_limit, evicted, kept, failures
                 );
             }
+            metrics.do_send(SetDataDirStats {
+                size_bytes: dir_size,
+                limit_bytes: size_limit,
+                evicted,
+                failures,
+            });
         })
     }
 }
@@ -162,23 +215,79 @@ async fn get_dir_entries(path: &Path) -> io::Result<Vec<(PathBuf, Metadata)>> {
     Ok(file_entries)
 }
 
-/// Return true if the file was deleted
-async fn attempt_removal(path: &Path, zstor: Addr<ZstorActor>) -> ZstorResult<bool> {
-    let path = fs::canonicalize(path).await.map_err(|e| {
-        ZstorError::new_io(
-            "Could not canonicalize path".into(),
-            io::Error::other(format!("Could not canonicalize path: {}", e)),
-        )
-    })?;
-    if zstor.send(Check { path: path.clone() }).await??.is_none() {
-        return Ok(false);
+/// Attempt to evict a single file. A file is only deleted when the metastore confirms that
+/// exactly this content has been dispersed, so an eviction can always be undone by a retrieve.
+async fn attempt_removal(path: &Path, zstor: Addr<ZstorActor>) -> ZstorResult<RemovalOutcome> {
+    // The metastore keys files by the lexically cleaned path they were stored with, so query
+    // that form first. Resolving the path on the filesystem instead (as older versions did)
+    // breaks the lookup for every file stored through a symlinked location: the store side
+    // never resolves symlinks, so the eviction side must not either.
+    let clean_path = crate::meta::canonicalize(path)
+        .map_err(|e| ZstorError::new_io("Could not clean path".into(), e))?;
+    let mut stored_checksum = zstor
+        .send(Check {
+            path: clean_path.clone(),
+        })
+        .await??;
+    if stored_checksum.is_none() {
+        // Fall back to the fully resolved path, in case the file was stored through a
+        // different spelling of the same location.
+        match fs::canonicalize(path).await {
+            Ok(resolved) => {
+                if resolved != clean_path {
+                    stored_checksum = zstor.send(Check { path: resolved }).await??;
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(RemovalOutcome::Vanished),
+            Err(e) => return Err(ZstorError::new_io("Could not canonicalize path".into(), e)),
+        }
+    }
+    let Some(expected) = stored_checksum else {
+        return Ok(RemovalOutcome::Kept("file is not (yet) dispersed"));
+    };
+
+    // Never delete content that doesn't match the dispersed copy: a retrieve would restore
+    // different data than what is on disk now.
+    match file_checksum(path).await {
+        Ok(actual) if actual == expected => {}
+        Ok(_) => {
+            warn!(
+                "Not evicting {:?}: local content diverged from the dispersed copy",
+                path
+            );
+            return Ok(RemovalOutcome::Kept(
+                "local content diverged from the dispersed copy",
+            ));
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(RemovalOutcome::Vanished),
+        Err(e) => return Err(ZstorError::new_io("Could not checksum file".into(), e)),
     }
 
-    // file is uploaded
-    fs::remove_file(&path).await.map(|_| true).map_err(|e| {
-        ZstorError::new_io(
-            "Could not remove file".into(),
-            io::Error::other(format!("Could not remove file: {}", e)),
-        )
-    })
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(RemovalOutcome::Removed),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(RemovalOutcome::Vanished),
+        Err(e) => Err(ZstorError::new_io("Could not remove file".into(), e)),
+    }
+}
+
+/// Get a 16 byte blake2b checksum of a file, the same checksum the store pipeline records in
+/// the metadata.
+async fn file_checksum(path: &Path) -> io::Result<Checksum> {
+    let mut file = fs::File::open(path).await?;
+    // The unwrap here is safe since we know that 16 is a valid output size.
+    let mut hasher = Blake2bVar::new(CHECKSUM_LENGTH).unwrap();
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    // The expect is safe due to the static size, which is known to be valid.
+    Ok(hasher
+        .finalize_boxed()
+        .as_ref()
+        .try_into()
+        .expect("Invalid hash size returned"))
 }

--- a/zstor/src/actors/explorer.rs
+++ b/zstor/src/actors/explorer.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 use actix::prelude::*;
 use log::warn;
-use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
 
 /// Drop in replacement for the [`ExplorerActor`] which does not connect to the threefold grid.
 pub struct NopExplorerActor;
@@ -74,15 +72,4 @@ impl Handler<ExpandStorage> for NopExplorerActor {
             ))
         })
     }
-}
-
-/// The json structure of the response in a 0-db reservation
-#[derive(Debug, Serialize, Deserialize)]
-struct ZdbResultJson {
-    #[serde(rename = "Namespace")]
-    namespace: String,
-    #[serde(rename = "IPs")]
-    ips: Vec<IpAddr>,
-    #[serde(rename = "Port")]
-    port: u16,
 }

--- a/zstor/src/actors/metrics.rs
+++ b/zstor/src/actors/metrics.rs
@@ -50,6 +50,11 @@ struct PromMetrics {
     index_disk_freespace_bytes_gauges: IntGaugeVec,
     data_disk_freespace_bytes_gauges: IntGaugeVec,
 
+    data_dir_size_bytes: IntGauge,
+    data_dir_size_limit_bytes: IntGauge,
+    data_dir_files_evicted: IntCounter,
+    data_dir_eviction_failures: IntCounter,
+
     zstor_store_commands_finished: IntCounterVec,
     zstor_retrieve_commands_finished: IntCounterVec,
     zstor_rebuild_commands_finished: IntCounterVec,
@@ -155,6 +160,26 @@ impl MetricsActor {
                 "data_disk_freespace_bytes",
                 "data_disk_freespace_bytes in namespace",
                 &["address", "namespace", "backend_type"]
+            )
+            .unwrap(),
+            data_dir_size_bytes: register_int_gauge!(
+                "data_dir_size_bytes",
+                "Total size of the files in the monitored 0-db data dir"
+            )
+            .unwrap(),
+            data_dir_size_limit_bytes: register_int_gauge!(
+                "data_dir_size_limit_bytes",
+                "Configured size limit of the monitored 0-db data dir"
+            )
+            .unwrap(),
+            data_dir_files_evicted: register_int_counter!(
+                "data_dir_files_evicted",
+                "Total amount of files evicted from the monitored 0-db data dir"
+            )
+            .unwrap(),
+            data_dir_eviction_failures: register_int_counter!(
+                "data_dir_eviction_failures",
+                "Total amount of failed eviction attempts in the monitored 0-db data dir"
             )
             .unwrap(),
             zstor_store_commands_finished: register_int_counter_vec!(
@@ -307,6 +332,20 @@ pub struct UpdateZdbFsStats {
     pub stats: stats_t,
 }
 
+/// Message updating the stats of the monitored 0-db data dir after an eviction pass.
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct SetDataDirStats {
+    /// Total size of the files in the data dir, after eviction.
+    pub size_bytes: u64,
+    /// The configured size limit of the data dir.
+    pub limit_bytes: u64,
+    /// The amount of files evicted in this pass.
+    pub evicted: u64,
+    /// The amount of files for which an eviction attempt failed in this pass.
+    pub failures: u64,
+}
+
 impl Actor for MetricsActor {
     type Context = Context<Self>;
 }
@@ -368,6 +407,23 @@ impl Handler<UpdateZdbFsStats> for MetricsActor {
 
     fn handle(&mut self, msg: UpdateZdbFsStats, _: &mut Self::Context) -> Self::Result {
         self.zdbfs_stats = msg.stats;
+    }
+}
+
+impl Handler<SetDataDirStats> for MetricsActor {
+    type Result = ();
+
+    fn handle(&mut self, msg: SetDataDirStats, _: &mut Self::Context) -> Self::Result {
+        self.prom_metrics
+            .data_dir_size_bytes
+            .set(msg.size_bytes as i64);
+        self.prom_metrics
+            .data_dir_size_limit_bytes
+            .set(msg.limit_bytes as i64);
+        self.prom_metrics.data_dir_files_evicted.inc_by(msg.evicted);
+        self.prom_metrics
+            .data_dir_eviction_failures
+            .inc_by(msg.failures);
     }
 }
 

--- a/zstor/src/actors/repairer.rs
+++ b/zstor/src/actors/repairer.rs
@@ -1,52 +1,82 @@
 use crate::actors::{
     backends::{BackendManagerActor, RequestBackends, StateInterest},
+    config::{ConfigActor, GetConfig},
     meta::{MetaStoreActor, ScanMeta},
     zstor::{Rebuild, ZstorActor},
 };
+use crate::{ZstorError, ZstorErrorKind};
 use actix::prelude::*;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Amount of time between starting a new sweep of the backend objects.
-const OBJECT_SWEEP_INTERVAL_SECONDS: u64 = 60 * 10;
-
 #[derive(Message)]
 #[rtype(result = "()")]
-/// Message to request a sweep of all objects in the [`MetaStore`]. If one or more backends are not
+/// Message to run a periodic sweep of all objects in the metastore, if unattended repair is
+/// enabled in the running config. If one or more backends holding shards of an object are not
 /// reachable, the object is repaired.
-struct SweepObjects;
+struct PeriodicSweep;
 
-/// Actor implementation of a repair queue. It periodically sweeps the [`MetaStore`], and verifies
-/// all backends are still reachable.
+/// Message to run a sweep of all objects in the metastore right now, regardless of whether
+/// unattended repair is enabled. This allows an external system which owns repair scheduling
+/// to trigger a sweep on demand.
+#[derive(Debug, Message, Serialize, Deserialize, Clone)]
+#[rtype(result = "Result<SweepReport, ZstorError>")]
+pub struct SweepNow;
+
+/// The result of a repair sweep over all objects in the metastore.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SweepReport {
+    /// Amount of objects inspected during the sweep.
+    pub objects: u64,
+    /// Amount of objects found with one or more shards on unreachable backends.
+    pub degraded: u64,
+    /// Amount of degraded objects successfully rebuilt onto healthy backends.
+    pub rebuilt: u64,
+    /// Amount of degraded objects which could not be rebuilt. Details are in the log.
+    pub failed: u64,
+}
+
+/// Actor implementation of a repair queue. It periodically sweeps the metastore, verifies all
+/// backends holding shards are still reachable, and rebuilds objects for which that is not the
+/// case. Sweeps can also be requested on demand with [`SweepNow`].
 pub struct RepairActor {
     meta: Addr<MetaStoreActor>,
     backend_manager: Addr<BackendManagerActor>,
     zstor: Addr<ZstorActor>,
+    cfg: Addr<ConfigActor>,
+    sweep_interval: Duration,
     handling_sweep_objects: Arc<AtomicBool>,
 }
 
 impl RepairActor {
     /// Create a new [`RepairActor`] checking objects in the provided metastore and using the given
-    /// zstor to repair them if needed.
+    /// zstor to repair them if needed. The sweep interval controls how often automatic sweeps
+    /// run; whether they run at all is read from the running config at every tick, so a config
+    /// reload can enable or disable unattended repair without a restart.
     pub fn new(
         meta: Addr<MetaStoreActor>,
         backend_manager: Addr<BackendManagerActor>,
         zstor: Addr<ZstorActor>,
+        cfg: Addr<ConfigActor>,
+        sweep_interval: Duration,
     ) -> RepairActor {
         Self {
             meta,
             backend_manager,
             zstor,
+            cfg,
+            sweep_interval,
             handling_sweep_objects: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Send a [`SweepObjects`] command to the actor.
-    fn sweep_objects(&mut self, ctx: &mut <Self as Actor>::Context) {
-        ctx.notify(SweepObjects);
+    /// Send a [`PeriodicSweep`] command to the actor.
+    fn periodic_sweep(&mut self, ctx: &mut <Self as Actor>::Context) {
+        ctx.notify(PeriodicSweep);
     }
 }
 
@@ -54,10 +84,7 @@ impl Actor for RepairActor {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(
-            Duration::from_secs(OBJECT_SWEEP_INTERVAL_SECONDS),
-            Self::sweep_objects,
-        );
+        ctx.run_interval(self.sweep_interval, Self::periodic_sweep);
     }
 }
 
@@ -71,102 +98,186 @@ impl Drop for SweepGuard {
     }
 }
 
-impl Handler<SweepObjects> for RepairActor {
-    type Result = ResponseFuture<()>;
+/// Sweep the metastore for objects with shards on unreachable backends and rebuild them. The
+/// caller must hold the sweep guard so no two sweeps run concurrently.
+async fn sweep_objects(
+    meta: Addr<MetaStoreActor>,
+    backend_manager: Addr<BackendManagerActor>,
+    zstor: Addr<ZstorActor>,
+) -> Result<SweepReport, ZstorError> {
+    let mut report = SweepReport {
+        objects: 0,
+        degraded: 0,
+        rebuilt: 0,
+        failed: 0,
+    };
 
-    fn handle(&mut self, _: SweepObjects, _: &mut Self::Context) -> Self::Result {
-        if self.handling_sweep_objects.swap(true, Ordering::Relaxed) {
-            log::info!("Dropping SweepObjects message - still processing");
-            return Box::pin(async {});
+    let start_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after the unix epoch")
+        .as_secs();
+
+    // start scanning from the beginning (cursor == None) and let the metastore choose the
+    // backend_id
+    let mut cursor = None;
+    let mut backend_idx = None;
+    loop {
+        // scan keys from the metastore
+        let (idx, new_cursor, metas) = meta
+            .send(ScanMeta {
+                cursor: cursor.clone(),
+                backend_idx,
+                max_timestamp: Some(start_time),
+            })
+            .await
+            .map_err(|e| {
+                ZstorError::with_message(
+                    ZstorErrorKind::Metadata,
+                    format!("could not request meta keys from metastore: {}", e),
+                )
+            })??;
+
+        // iterate over the keys and check if the backends are healthy
+        // if not, rebuild the object
+        for (key, metadata) in metas.into_iter() {
+            report.objects += 1;
+            let backend_requests = metadata
+                .shards()
+                .iter()
+                .map(|shard_info| shard_info.zdb())
+                .cloned()
+                .collect::<Vec<_>>();
+            let backends = backend_manager
+                .send(RequestBackends {
+                    backend_requests,
+                    interest: StateInterest::Readable,
+                })
+                .await
+                .map_err(|e| {
+                    ZstorError::with_message(
+                        ZstorErrorKind::Storage,
+                        format!("failed to request backends: {}", e),
+                    )
+                })?;
+            let must_rebuild = backends.into_iter().any(|b| !matches!(b, Ok(Some(_))));
+            if must_rebuild {
+                report.degraded += 1;
+                match zstor
+                    .send(Rebuild {
+                        file: None,
+                        key: Some(key.clone()),
+                        metadata: Some(metadata),
+                    })
+                    .await
+                {
+                    Ok(Ok(())) => {
+                        report.rebuilt += 1;
+                        info!("Repaired object {}", key);
+                    }
+                    Ok(Err(e)) => {
+                        report.failed += 1;
+                        error!("Could not repair object {}: {}", key, e);
+                    }
+                    Err(e) => {
+                        report.failed += 1;
+                        error!("Could not deliver repair command for object {}: {}", key, e);
+                    }
+                }
+            }
         }
 
+        if new_cursor.is_none() {
+            debug!("there is no more old data to rebuild");
+            break;
+        }
+
+        cursor = new_cursor;
+        backend_idx = Some(idx);
+    }
+
+    Ok(report)
+}
+
+/// Log the outcome of a finished sweep at a level matching its severity.
+fn log_sweep_report(report: &SweepReport) {
+    if report.failed > 0 {
+        warn!(
+            "Repair sweep finished with failures: {} objects checked, {} degraded, {} rebuilt, {} FAILED - the failed objects are still missing shards",
+            report.objects, report.degraded, report.rebuilt, report.failed
+        );
+    } else {
+        info!(
+            "Repair sweep finished: {} objects checked, {} degraded, {} rebuilt",
+            report.objects, report.degraded, report.rebuilt
+        );
+    }
+}
+
+impl Handler<PeriodicSweep> for RepairActor {
+    type Result = ResponseFuture<()>;
+
+    fn handle(&mut self, _: PeriodicSweep, _: &mut Self::Context) -> Self::Result {
+        let meta = self.meta.clone();
+        let backend_manager = self.backend_manager.clone();
+        let zstor = self.zstor.clone();
+        let cfg = self.cfg.clone();
+        let handling_sweep_objects = Arc::clone(&self.handling_sweep_objects);
+
+        Box::pin(async move {
+            match cfg.send(GetConfig).await {
+                Ok(config) => {
+                    if !config.unattended_repair() {
+                        debug!("Skipping periodic repair sweep - unattended repair is disabled");
+                        return;
+                    }
+                }
+                Err(e) => {
+                    error!("Could not get running config for periodic sweep: {}", e);
+                    return;
+                }
+            }
+
+            if handling_sweep_objects.swap(true, Ordering::Relaxed) {
+                info!("Dropping periodic repair sweep - a sweep is already running");
+                return;
+            }
+            let _guard = SweepGuard {
+                flag: handling_sweep_objects,
+            };
+
+            info!("Starting periodic repair sweep");
+            match sweep_objects(meta, backend_manager, zstor).await {
+                Ok(report) => log_sweep_report(&report),
+                Err(e) => error!("Repair sweep aborted: {}", e),
+            }
+        })
+    }
+}
+
+impl Handler<SweepNow> for RepairActor {
+    type Result = ResponseFuture<Result<SweepReport, ZstorError>>;
+
+    fn handle(&mut self, _: SweepNow, _: &mut Self::Context) -> Self::Result {
         let meta = self.meta.clone();
         let backend_manager = self.backend_manager.clone();
         let zstor = self.zstor.clone();
         let handling_sweep_objects = Arc::clone(&self.handling_sweep_objects);
 
-        log::info!("Starting SweepObjects");
         Box::pin(async move {
+            if handling_sweep_objects.swap(true, Ordering::Relaxed) {
+                return Err(ZstorError::with_message(
+                    ZstorErrorKind::Storage,
+                    "a repair sweep is already running".to_string(),
+                ));
+            }
             let _guard = SweepGuard {
-                flag: Arc::clone(&handling_sweep_objects),
+                flag: handling_sweep_objects,
             };
 
-            let start_time = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-
-            // start scanning from the beginning (cursor == None) and let the metastore choose the backend_id
-            let mut cursor = None;
-            let mut backend_idx = None;
-            loop {
-                // scan keys from the metastore
-                let (idx, new_cursor, metas) = match meta
-                    .send(ScanMeta {
-                        cursor: cursor.clone(),
-                        backend_idx,
-                        max_timestamp: Some(start_time),
-                    })
-                    .await
-                {
-                    Err(e) => {
-                        error!("Could not request meta keys from metastore: {}", e);
-                        return;
-                    }
-                    Ok(result) => match result {
-                        Err(e) => {
-                            error!("Could not get meta keys from metastore: {}", e);
-                            return;
-                        }
-                        Ok(res) => res,
-                    },
-                };
-
-                // iterate over the keys and check if the backends are healthy
-                // if not, rebuild the object
-                for (key, metadata) in metas.into_iter() {
-                    let backend_requests = metadata
-                        .shards()
-                        .iter()
-                        .map(|shard_info| shard_info.zdb())
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    let backends = match backend_manager
-                        .send(RequestBackends {
-                            backend_requests,
-                            interest: StateInterest::Readable,
-                        })
-                        .await
-                    {
-                        Err(e) => {
-                            error!("Failed to request backends: {}", e);
-                            return;
-                        }
-                        Ok(backends) => backends,
-                    };
-                    let must_rebuild = backends.into_iter().any(|b| !matches!(b, Ok(Some(_))));
-                    if must_rebuild {
-                        if let Err(e) = zstor
-                            .send(Rebuild {
-                                file: None,
-                                key: Some(key),
-                                metadata: Some(metadata),
-                            })
-                            .await
-                        {
-                            warn!("Failed to rebuild data: {}", e);
-                        }
-                    }
-                }
-
-                if new_cursor.is_none() {
-                    debug!("there is no more old data to rebuild");
-                    break;
-                }
-
-                cursor = new_cursor;
-                backend_idx = Some(idx);
-            }
+            info!("Starting requested repair sweep");
+            let report = sweep_objects(meta, backend_manager, zstor).await?;
+            log_sweep_report(&report);
+            Ok(report)
         })
     }
 }

--- a/zstor/src/actors/repairer.rs
+++ b/zstor/src/actors/repairer.rs
@@ -137,8 +137,8 @@ async fn sweep_objects(
                 )
             })??;
 
-        // iterate over the keys and check if the backends are healthy
-        // if not, rebuild the object
+        // iterate over the keys and check if all shards are placed and all backends holding
+        // them are healthy; if not, rebuild the object
         for (key, metadata) in metas.into_iter() {
             report.objects += 1;
             let backend_requests = metadata
@@ -147,6 +147,10 @@ async fn sweep_objects(
                 .map(|shard_info| shard_info.zdb())
                 .cloned()
                 .collect::<Vec<_>>();
+            // An object written while backends were down holds fewer shards than intended
+            // (degraded write); rebuilding it backfills the missing shards.
+            let missing_shards =
+                metadata.data_shards() + metadata.disposable_shards() > metadata.shards().len();
             let backends = backend_manager
                 .send(RequestBackends {
                     backend_requests,
@@ -159,7 +163,8 @@ async fn sweep_objects(
                         format!("failed to request backends: {}", e),
                     )
                 })?;
-            let must_rebuild = backends.into_iter().any(|b| !matches!(b, Ok(Some(_))));
+            let must_rebuild =
+                missing_shards || backends.into_iter().any(|b| !matches!(b, Ok(Some(_))));
             if must_rebuild {
                 report.degraded += 1;
                 match zstor

--- a/zstor/src/actors/zstor.rs
+++ b/zstor/src/actors/zstor.rs
@@ -254,17 +254,27 @@ impl Handler<Retrieve> for ZstorActor {
         AtomicResponse::new(Box::pin(
             async move {
                 let cfg = config.send(GetConfig).await?;
-                let metadata = meta
+                let mut metadata = meta
                     .send(LoadMeta {
                         path: msg.file.clone(),
                     })
-                    .await??
-                    .ok_or_else(|| {
-                        ZstorError::new_io(
-                            "no metadata found for file".to_string(),
-                            std::io::Error::from(std::io::ErrorKind::NotFound),
-                        )
-                    })?;
+                    .await??;
+                if metadata.is_none() {
+                    // The store pipeline keys metadata by the fully resolved path, so a file
+                    // addressed through a symlinked or relative location would never find its
+                    // own metadata under the path it was requested with.
+                    if let Ok(resolved) = resolve_path(&msg.file).await {
+                        if resolved != msg.file {
+                            metadata = meta.send(LoadMeta { path: resolved }).await??;
+                        }
+                    }
+                }
+                let metadata = metadata.ok_or_else(|| {
+                    ZstorError::new_io(
+                        "no metadata found for file".to_string(),
+                        std::io::Error::from(std::io::ErrorKind::NotFound),
+                    )
+                })?;
 
                 let shards = load_data(&metadata, 1).await?;
 
@@ -779,6 +789,22 @@ async fn rebuild_data(
     }
 
     Ok(())
+}
+
+/// Fully resolve a path on the filesystem, even when the file itself does not exist (the
+/// parent directory must). This mirrors how the store pipeline canonicalizes the paths it
+/// keys metadata under.
+async fn resolve_path(path: &Path) -> io::Result<PathBuf> {
+    match fs::canonicalize(path).await {
+        Ok(resolved) => Ok(resolved),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let (Some(parent), Some(name)) = (path.parent(), path.file_name()) else {
+                return Err(e);
+            };
+            Ok(fs::canonicalize(parent).await?.join(name))
+        }
+        Err(e) => Err(e),
+    }
 }
 
 async fn save_data(

--- a/zstor/src/actors/zstor.rs
+++ b/zstor/src/actors/zstor.rs
@@ -355,21 +355,28 @@ impl Handler<Rebuild> for ZstorActor {
                     })
                     .await??;
 
-                // build a list of (key, backend used for the shards)
+                // build a list of (key, backend used for the shards), indexed by shard
+                // position:
                 // - if the shard still exists in the backend, we set the backend to the old backend
-                // - if the shard is missing, we set the backend to None
-                let mut used_backends = Vec::new();
-                for (i, data) in existing_data.iter().enumerate() {
-                    let key = old_metadata.shards()[i].key().to_vec();
-                    if let Some(data) = data {
-                        if data.as_slice() == shards[i].as_ref() {
-                            used_backends.push((key, Some(old_metadata.shards()[i].zdb().clone())));
-                        } else {
-                            used_backends.push((key, None));
-                            error!("Shard {} is DIFFERENT", i);
+                // - if the shard is missing (unreachable backend, corrupt data, or never placed
+                //   because the object was written degraded), we set the backend to None
+                let expected_shards = old_metadata.data_shards() + old_metadata.disposable_shards();
+                let mut used_backends = Vec::with_capacity(expected_shards);
+                for position in 0..expected_shards {
+                    let old_shard = old_metadata
+                        .shards()
+                        .iter()
+                        .find(|si| si.index() == position);
+                    let key = old_shard.map(|si| si.key().to_vec()).unwrap_or_default();
+                    match (old_shard, existing_data[position].as_ref()) {
+                        (Some(si), Some(data)) if data.as_slice() == shards[position].as_ref() => {
+                            used_backends.push((key, Some(si.zdb().clone())));
                         }
-                    } else {
-                        used_backends.push((key, None));
+                        (Some(_), Some(_)) => {
+                            error!("Shard {} is DIFFERENT", position);
+                            used_backends.push((key, None));
+                        }
+                        _ => used_backends.push((key, None)),
                     }
                 }
 
@@ -567,6 +574,41 @@ async fn find_valid_backends(
     }
 }
 
+/// Probe every backend in the config which is not in `used`, and return the healthy ones
+/// tagged with their group index, together with the amount of `used` backends per group.
+/// The group counts serve as the starting load for [`pick_least_loaded_groups`], so
+/// follow-up picks keep the object spread over the configured groups.
+async fn probe_spare_backends(
+    cfg: &Config,
+    shard_len: usize,
+    used: &[&ZdbConnectionInfo],
+) -> (Vec<(usize, SequentialZdb)>, Vec<usize>) {
+    let mut group_load: Vec<usize> = vec![0; cfg.groups().len()];
+    let mut candidates = Vec::new();
+    for (group_idx, group) in cfg.groups().iter().enumerate() {
+        for backend in group.backends() {
+            if used.contains(&backend) {
+                group_load[group_idx] += 1;
+            } else {
+                candidates.push((group_idx, backend.clone()));
+            }
+        }
+    }
+
+    let probes = candidates.into_iter().map(|(group_idx, ci)| async move {
+        (group_idx, check_backend_space(ci, shard_len).await)
+    });
+    let mut healthy = Vec::new();
+    for (group_idx, result) in join_all(probes).await {
+        match result {
+            Ok(db) => healthy.push((group_idx, db)),
+            Err(e) => debug!("Skipping backend candidate: {}", e),
+        }
+    }
+
+    (healthy, group_load)
+}
+
 /// Find backends to hold rebuilt shards.
 ///
 /// Candidates are all backends in the config which do not already hold a live shard of the
@@ -587,30 +629,7 @@ async fn find_rebuild_backends(
         .filter_map(|(_, ci)| ci.as_ref())
         .collect();
 
-    // Track how many live shards of this object every group already holds, and collect the
-    // backends which are candidates for the missing shards.
-    let mut group_load: Vec<usize> = vec![0; cfg.groups().len()];
-    let mut candidates = Vec::new();
-    for (group_idx, group) in cfg.groups().iter().enumerate() {
-        for backend in group.backends() {
-            if used.contains(&backend) {
-                group_load[group_idx] += 1;
-            } else {
-                candidates.push((group_idx, backend.clone()));
-            }
-        }
-    }
-
-    let probes = candidates.into_iter().map(|(group_idx, ci)| async move {
-        (group_idx, check_backend_space(ci, shard_len).await)
-    });
-    let mut healthy = Vec::new();
-    for (group_idx, result) in join_all(probes).await {
-        match result {
-            Ok(db) => healthy.push((group_idx, db)),
-            Err(e) => debug!("Skipping rebuild target candidate: {}", e),
-        }
-    }
+    let (healthy, mut group_load) = probe_spare_backends(cfg, shard_len, &used).await;
 
     if healthy.len() < needed_backends {
         return Err(ZstorError::with_message(
@@ -628,6 +647,32 @@ async fn find_rebuild_backends(
         &mut group_load,
         needed_backends,
     ))
+}
+
+/// Find backends for a degraded write: as many healthy backends as available, up to
+/// `wanted`, spread over the groups, as long as at least `minimum` can be found. Used when
+/// the regular placement cannot be satisfied because backends are unreachable or full.
+async fn find_degraded_write_backends(
+    cfg: &Config,
+    shard_len: usize,
+    wanted: usize,
+    minimum: usize,
+) -> ZstorResult<Vec<SequentialZdb>> {
+    let (healthy, mut group_load) = probe_spare_backends(cfg, shard_len, &[]).await;
+
+    if healthy.len() < minimum {
+        return Err(ZstorError::with_message(
+            ZstorErrorKind::Storage,
+            format!(
+                "insufficient healthy backends even for a degraded write: {} healthy, need at least {} (minimal shards + degraded write margin)",
+                healthy.len(),
+                minimum
+            ),
+        ));
+    }
+
+    let amount = healthy.len().min(wanted);
+    Ok(pick_least_loaded_groups(healthy, &mut group_load, amount))
 }
 
 /// Pick `needed` entries out of `candidates`, always taking a candidate from the group with the
@@ -747,11 +792,33 @@ async fn save_data(
         shards[0].len()
     };
 
-    let dbs = find_valid_backends(cfg, shard_len, shards.len()).await?;
+    let wanted = shards.len();
+    let dbs = match find_valid_backends(cfg, shard_len, wanted).await {
+        Ok(dbs) => dbs,
+        Err(e) => {
+            // A full placement is not possible right now (backends unreachable or full).
+            // Rather than refusing the write - which turns one dead backend into a stalled
+            // fabric - degrade: place as many shards as healthy backends allow, as long as
+            // the data stays recoverable with a margin. The missing shards are backfilled
+            // by the repair sweep once capacity returns.
+            let minimum = cfg.data_shards() + cfg.degraded_write_margin();
+            let dbs = find_degraded_write_backends(cfg, shard_len, wanted, minimum).await?;
+            warn!(
+                "Degraded write: only {} of {} shards can be placed (full placement failed: {})",
+                dbs.len(),
+                wanted,
+                e
+            );
+            dbs
+        }
+    };
 
     trace!("store shards in backends");
 
-    let mut handles: Vec<JoinHandle<ZstorResult<_>>> = Vec::with_capacity(shards.len());
+    let mut handles: Vec<JoinHandle<ZstorResult<_>>> = Vec::with_capacity(dbs.len());
+    // In a degraded write fewer backends than shards are available; the zip drops the
+    // unplaceable tail. Any `minimal_shards` shards recover the data, so which shards are
+    // dropped does not matter.
     for (db, (shard_idx, shard)) in dbs.into_iter().zip(shards.into_iter().enumerate()) {
         handles.push(tokio::spawn(async move {
             let keys = db.set(&shard).await?;

--- a/zstor/src/actors/zstor.rs
+++ b/zstor/src/actors/zstor.rs
@@ -9,7 +9,7 @@ use crate::{
     erasure::Shard,
     meta::{Checksum, MetaData, ShardInfo},
     zdb::{Key, SequentialZdb, ZdbConnectionInfo, ZdbError, ZdbResult},
-    ZstorError, ZstorResult,
+    ZstorError, ZstorErrorKind, ZstorResult,
 };
 use actix::prelude::*;
 use futures::future::{join_all, try_join_all};
@@ -21,7 +21,11 @@ use std::{
 };
 use tokio::{fs, io, task::JoinHandle};
 
-use super::{backends::BackendManagerActor, config::ReloadConfig};
+use super::{
+    backends::BackendManagerActor,
+    config::ReloadConfig,
+    repairer::{SweepNow, SweepReport},
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// All possible commands zstor operates on.
@@ -34,6 +38,8 @@ pub enum ZstorCommand {
     Rebuild(Rebuild),
     /// Command to check if a file exists in the backend.
     Check(Check),
+    /// Command to run a repair sweep over all stored objects.
+    Sweep(SweepNow),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -45,6 +51,8 @@ pub enum ZstorResponse {
     Err(String),
     /// A checksum of a file.
     Checksum(Checksum),
+    /// The report of a completed repair sweep.
+    Sweep(SweepReport),
 }
 
 #[derive(Serialize, Deserialize, Debug, Message, Clone)]
@@ -365,13 +373,7 @@ impl Handler<Rebuild> for ZstorActor {
                     }
                 }
 
-                rebuild_data(
-                    &mut cfg.deref().clone(),
-                    shards,
-                    &mut metadata,
-                    used_backends,
-                )
-                .await?;
+                rebuild_data(cfg.deref(), shards, &mut metadata, used_backends).await?;
 
                 info!(
                     "Rebuild file from {} to {}",
@@ -528,12 +530,10 @@ async fn check_backend_space(
 }
 
 // Find valid backends for the shards
-// if the backend is part of the skip_backends, we don't need to check it again
 async fn find_valid_backends(
     cfg: &mut Config,
     shard_len: usize,
     needed_backends: usize,
-    skip_backends: Vec<(Vec<Key>, Option<ZdbConnectionInfo>)>,
 ) -> ZstorResult<Vec<SequentialZdb>> {
     loop {
         debug!("Finding backend config");
@@ -543,11 +543,6 @@ async fn find_valid_backends(
 
         let handles: Vec<_> = backends
             .into_iter()
-            .filter(|backend| {
-                !skip_backends
-                    .iter()
-                    .any(|(_, b)| b.as_ref() == Some(backend))
-            })
             .map(|backend| {
                 tokio::spawn(async move { check_backend_space(backend, shard_len).await })
             })
@@ -572,8 +567,99 @@ async fn find_valid_backends(
     }
 }
 
+/// Find backends to hold rebuilt shards.
+///
+/// Candidates are all backends in the config which do not already hold a live shard of the
+/// object being rebuilt. Every candidate is probed, and the healthy ones are picked in an
+/// order which prefers groups holding the fewest live shards of this object, so the rebuilt
+/// object keeps its spread over the configured groups. Unlike the write path, this does not
+/// require every configured backend to be healthy: as long as enough healthy candidates
+/// exist to hold the missing shards, the rebuild can proceed - which is exactly the state a
+/// fabric is in after losing a backend while a spare is configured.
+async fn find_rebuild_backends(
+    cfg: &Config,
+    shard_len: usize,
+    needed_backends: usize,
+    used_backends: &[(Vec<Key>, Option<ZdbConnectionInfo>)],
+) -> ZstorResult<Vec<SequentialZdb>> {
+    let used: Vec<&ZdbConnectionInfo> = used_backends
+        .iter()
+        .filter_map(|(_, ci)| ci.as_ref())
+        .collect();
+
+    // Track how many live shards of this object every group already holds, and collect the
+    // backends which are candidates for the missing shards.
+    let mut group_load: Vec<usize> = vec![0; cfg.groups().len()];
+    let mut candidates = Vec::new();
+    for (group_idx, group) in cfg.groups().iter().enumerate() {
+        for backend in group.backends() {
+            if used.contains(&backend) {
+                group_load[group_idx] += 1;
+            } else {
+                candidates.push((group_idx, backend.clone()));
+            }
+        }
+    }
+
+    let probes = candidates.into_iter().map(|(group_idx, ci)| async move {
+        (group_idx, check_backend_space(ci, shard_len).await)
+    });
+    let mut healthy = Vec::new();
+    for (group_idx, result) in join_all(probes).await {
+        match result {
+            Ok(db) => healthy.push((group_idx, db)),
+            Err(e) => debug!("Skipping rebuild target candidate: {}", e),
+        }
+    }
+
+    if healthy.len() < needed_backends {
+        return Err(ZstorError::with_message(
+            ZstorErrorKind::Storage,
+            format!(
+                "cannot rebuild to full redundancy: {} healthy spare backend(s) available, {} needed - provision replacement capacity or restore the missing backend(s)",
+                healthy.len(),
+                needed_backends
+            ),
+        ));
+    }
+
+    Ok(pick_least_loaded_groups(
+        healthy,
+        &mut group_load,
+        needed_backends,
+    ))
+}
+
+/// Pick `needed` entries out of `candidates`, always taking a candidate from the group with the
+/// lowest current load, and counting every pick towards that group's load. This keeps the picks
+/// spread over the groups.
+///
+/// # Panics
+///
+/// Panics if `candidates` holds fewer than `needed` entries.
+fn pick_least_loaded_groups<T>(
+    mut candidates: Vec<(usize, T)>,
+    group_load: &mut [usize],
+    needed: usize,
+) -> Vec<T> {
+    let mut picked = Vec::with_capacity(needed);
+    while picked.len() < needed {
+        // Unwrap is safe: candidates holds at least the amount of entries still to be picked.
+        let least_loaded = candidates
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, (group_idx, _))| group_load[*group_idx])
+            .map(|(idx, _)| idx)
+            .unwrap();
+        let (group_idx, entry) = candidates.swap_remove(least_loaded);
+        group_load[group_idx] += 1;
+        picked.push(entry);
+    }
+    picked
+}
+
 async fn rebuild_data(
-    cfg: &mut Config,
+    cfg: &Config,
     shards: Vec<Shard>,
     metadata: &mut MetaData,
     // used_backends specifies which backends are already used
@@ -592,11 +678,11 @@ async fn rebuild_data(
         }
     }
 
-    let new_dbs = find_valid_backends(
+    let new_dbs = find_rebuild_backends(
         cfg,
         shard_len,
         shards.len() - existing_backends_num,
-        used_backends.clone(),
+        &used_backends,
     )
     .await?;
 
@@ -661,7 +747,7 @@ async fn save_data(
         shards[0].len()
     };
 
-    let dbs = find_valid_backends(cfg, shard_len, shards.len(), [].to_vec()).await?;
+    let dbs = find_valid_backends(cfg, shard_len, shards.len()).await?;
 
     trace!("store shards in backends");
 
@@ -704,4 +790,47 @@ async fn get_dir_entries(dir: &Path) -> io::Result<Vec<PathBuf>> {
     }
 
     Ok(dir_entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_least_loaded_groups;
+
+    #[test]
+    fn picks_spread_over_empty_groups() {
+        // Object lost its shard on a backend in group 0; groups 0 and 1 still hold one shard
+        // each, group 2 holds none. The replacement should land in group 2.
+        let candidates = vec![(0, "spare_g0"), (2, "spare_g2")];
+        let mut load = vec![1, 1, 0];
+        let picked = pick_least_loaded_groups(candidates, &mut load, 1);
+        assert_eq!(picked, vec!["spare_g2"]);
+        assert_eq!(load, vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn picks_count_towards_group_load() {
+        // Two picks with two spares in the empty group 1 and one in group 0: the second pick
+        // must not land in group 1 again, even though it started out least loaded.
+        let candidates = vec![(0, "spare_g0"), (1, "spare_g1_a"), (1, "spare_g1_b")];
+        let mut load = vec![1, 0];
+        let picked = pick_least_loaded_groups(candidates, &mut load, 2);
+        assert!(picked.contains(&"spare_g0"));
+        assert_eq!(
+            picked
+                .iter()
+                .filter(|name| name.starts_with("spare_g1"))
+                .count(),
+            1
+        );
+        assert_eq!(load, vec![2, 1]);
+    }
+
+    #[test]
+    fn picks_exhaust_balanced_groups() {
+        let candidates = vec![(0, "a"), (0, "b"), (1, "c"), (1, "d")];
+        let mut load = vec![0, 0];
+        let picked = pick_least_loaded_groups(candidates, &mut load, 4);
+        assert_eq!(picked.len(), 4);
+        assert_eq!(load, vec![2, 2]);
+    }
 }

--- a/zstor/src/actors/zstor_scheduler.rs
+++ b/zstor/src/actors/zstor_scheduler.rs
@@ -1,4 +1,5 @@
 use super::priority_queue::PriorityQueue;
+use super::repairer::SweepReport;
 use super::zstor::{Check, Rebuild, Retrieve, Store, ZstorActor, ZstorCommand};
 use crate::{meta::Checksum, ZstorError, ZstorErrorKind};
 use actix::prelude::*;
@@ -48,6 +49,8 @@ pub enum ZstorSchedulerResponse {
     Retrieve(Result<(), ZstorError>),
     /// Response for store command
     Store(Result<(), ZstorError>),
+    /// Response for sweep command
+    Sweep(Result<SweepReport, ZstorError>),
     /// Response for finalize command
     Done,
 }
@@ -123,6 +126,15 @@ impl Looper {
                     .await
                     .unwrap_or_else(|e| Err(ZstorError::from(e))),
             ),
+            // Sweeps are handled by the repair actor directly and never enter the scheduler
+            // queue; refuse defensively should that ever change.
+            ZstorCommand::Sweep(_) => {
+                error!("repair sweeps cannot be processed by the command scheduler");
+                ZstorSchedulerResponse::Sweep(Err(ZstorError::with_message(
+                    ZstorErrorKind::Storage,
+                    "repair sweeps cannot be processed by the command scheduler".to_string(),
+                )))
+            }
         }
     }
 

--- a/zstor/src/actors/zstor_scheduler.rs
+++ b/zstor/src/actors/zstor_scheduler.rs
@@ -100,6 +100,9 @@ impl Looper {
         }
     }
 
+    // The wrapped responses carry ZstorError, which clippy considers large; boxing it is a
+    // crate-wide refactor out of scope here, and the same lint is already allowed elsewhere.
+    #[allow(clippy::result_large_err)]
     async fn forward_cmd(&self, cmd: ZstorCommand) -> ZstorSchedulerResponse {
         match cmd {
             ZstorCommand::Store(store) => ZstorSchedulerResponse::Store(

--- a/zstor/src/config.rs
+++ b/zstor/src/config.rs
@@ -58,6 +58,15 @@ pub struct Config {
     /// Time in seconds a backend can be unreachable before it is considered gone, making its
     /// shards eligible for repair. Defaults to 900 seconds.
     pub missing_backend_grace_secs: Option<u64>,
+    /// The amount of shards which must be placed on top of the minimal amount needed to
+    /// recover the data, for a write to be accepted when not all expected shards can be
+    /// placed (because backends are unreachable or full). Writes always place all expected
+    /// shards when possible; this margin only bounds how far a write may degrade before it is
+    /// refused. Missing shards are backfilled by the repair sweep once capacity returns.
+    /// Defaults to 1, so a freshly written object always survives at least one further
+    /// backend loss. Set it to `expected_shards - minimal_shards` to refuse any degraded
+    /// write.
+    pub degraded_write_margin: Option<usize>,
     /// configuration to use for the encryption stage.
     pub encryption: Encryption,
     /// configuration to use for the compression stage.
@@ -169,6 +178,13 @@ impl Config {
     /// seconds when not set in the config.
     pub fn missing_backend_grace(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.missing_backend_grace_secs.unwrap_or(900))
+    }
+
+    /// The amount of shards which must be placed on top of the minimal amount needed to
+    /// recover the data, for a degraded write to be accepted. Defaults to 1 when not set in
+    /// the config.
+    pub fn degraded_write_margin(&self) -> usize {
+        self.degraded_write_margin.unwrap_or(1)
     }
 
     /// Return the encryption config to use for encoding this object.
@@ -499,6 +515,7 @@ mod tests {
             unattended_repair: None,
             repair_interval_secs: None,
             missing_backend_grace_secs: None,
+            degraded_write_margin: None,
             groups: vec![
                 super::Group {
                     backends: vec![saddr, saddr2],
@@ -666,6 +683,7 @@ password = "supersecretpass"
             unattended_repair: None,
             repair_interval_secs: None,
             missing_backend_grace_secs: None,
+            degraded_write_margin: None,
             groups: vec![
                 super::Group {
                     backends: vec![saddr, saddr2],

--- a/zstor/src/config.rs
+++ b/zstor/src/config.rs
@@ -47,6 +47,17 @@ pub struct Config {
     /// An optional port on which prometheus metrics will be exposed. If this is not set, the
     /// metrics will not get exposed.
     pub prometheus_port: Option<u16>,
+    /// Whether the monitor repairs degraded objects on its own. If enabled (the default), the
+    /// monitor periodically scans all stored objects and rebuilds those with shards on
+    /// unreachable backends. If disabled, scans only run when explicitly requested (through the
+    /// sweep command), so an external system can own repair scheduling.
+    pub unattended_repair: Option<bool>,
+    /// Time in seconds between automatic repair scans of all stored objects. Only relevant when
+    /// unattended repair is enabled. Defaults to 600 seconds.
+    pub repair_interval_secs: Option<u64>,
+    /// Time in seconds a backend can be unreachable before it is considered gone, making its
+    /// shards eligible for repair. Defaults to 900 seconds.
+    pub missing_backend_grace_secs: Option<u64>,
     /// configuration to use for the encryption stage.
     pub encryption: Encryption,
     /// configuration to use for the compression stage.
@@ -140,6 +151,24 @@ impl Config {
     /// Return the prometheus port on which prometheus formatted metrics will be served, if one is set.
     pub fn prometheus_port(&self) -> Option<u16> {
         self.prometheus_port
+    }
+
+    /// Whether the monitor repairs degraded objects on its own. Defaults to `true` when not set
+    /// in the config.
+    pub fn unattended_repair(&self) -> bool {
+        self.unattended_repair.unwrap_or(true)
+    }
+
+    /// The time between automatic repair scans. Defaults to 600 seconds when not set in the
+    /// config.
+    pub fn repair_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.repair_interval_secs.unwrap_or(600))
+    }
+
+    /// The time a backend can be unreachable before it is considered gone. Defaults to 900
+    /// seconds when not set in the config.
+    pub fn missing_backend_grace(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.missing_backend_grace_secs.unwrap_or(900))
     }
 
     /// Return the encryption config to use for encoding this object.
@@ -467,6 +496,9 @@ mod tests {
             zdbfs_mountpoint: Some("/tmp/test".into()),
             prometheus_port: None,
             max_zdb_data_dir_size: None,
+            unattended_repair: None,
+            repair_interval_secs: None,
+            missing_backend_grace_secs: None,
             groups: vec![
                 super::Group {
                     backends: vec![saddr, saddr2],
@@ -631,6 +663,9 @@ password = "supersecretpass"
             zdbfs_mountpoint: Some("/tmp/test".into()),
             prometheus_port: None,
             max_zdb_data_dir_size: None,
+            unattended_repair: None,
+            repair_interval_secs: None,
+            missing_backend_grace_secs: None,
             groups: vec![
                 super::Group {
                     backends: vec![saddr, saddr2],

--- a/zstor/src/config.rs
+++ b/zstor/src/config.rs
@@ -274,14 +274,14 @@ impl Config {
         // acceptable to not find any good setup.
 
         // used groups must be <= disposable_shards/redundant_nodes, otherwise losing the max amount
-        // of nodes per group will lose too many shards
-        let max_groups = if self.redundant_nodes == 0 {
-            self.groups.len()
-        } else {
-            // add the redundant groups to the max groups, if we lose the entire group we no longer
-            // care about the individual nodes in the group after all
-            self.disposable_shards() / self.redundant_nodes + self.redundant_groups
-        };
+        // of nodes per group will lose too many shards. If no nodes are redundant, every group
+        // can be used. Otherwise, add the redundant groups to the max groups: if we lose the
+        // entire group we no longer care about the individual nodes in the group after all.
+        let max_groups = self
+            .disposable_shards()
+            .checked_div(self.redundant_nodes)
+            .map(|groups| groups + self.redundant_groups)
+            .unwrap_or(self.groups.len());
         // Get the index of every group for later lookup, eliminate groups which are statically too
         // small
         let groups: Vec<_> = self

--- a/zstor/src/config.rs
+++ b/zstor/src/config.rs
@@ -41,6 +41,9 @@ pub struct Config {
     /// Maximum size of the data dir in MiB, if this is set and the sum of the file sizes in the
     /// data dir gets higher than this value, the least used, already encoded file will be removed.
     pub max_zdb_data_dir_size: Option<u64>,
+    /// Time in seconds between checks of the data dir size. Only relevant when a data dir path
+    /// and size limit are set. Defaults to 60 seconds.
+    pub zdb_data_dir_check_interval_secs: Option<u64>,
     /// The mount point of an optional 0-db-fs. If present, stats will be collected from the
     /// 0-db-fs process.
     pub zdbfs_mountpoint: Option<PathBuf>,
@@ -178,6 +181,12 @@ impl Config {
     /// seconds when not set in the config.
     pub fn missing_backend_grace(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.missing_backend_grace_secs.unwrap_or(900))
+    }
+
+    /// The time between checks of the data dir size. Defaults to 60 seconds when not set in
+    /// the config.
+    pub fn zdb_data_dir_check_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.zdb_data_dir_check_interval_secs.unwrap_or(60))
     }
 
     /// The amount of shards which must be placed on top of the minimal amount needed to
@@ -512,6 +521,7 @@ mod tests {
             zdbfs_mountpoint: Some("/tmp/test".into()),
             prometheus_port: None,
             max_zdb_data_dir_size: None,
+            zdb_data_dir_check_interval_secs: None,
             unattended_repair: None,
             repair_interval_secs: None,
             missing_backend_grace_secs: None,
@@ -680,6 +690,7 @@ password = "supersecretpass"
             zdbfs_mountpoint: Some("/tmp/test".into()),
             prometheus_port: None,
             max_zdb_data_dir_size: None,
+            zdb_data_dir_check_interval_secs: None,
             unattended_repair: None,
             repair_interval_secs: None,
             missing_backend_grace_secs: None,

--- a/zstor/src/lib.rs
+++ b/zstor/src/lib.rs
@@ -59,8 +59,18 @@ pub mod zdbfs;
 /// Global result type for zstor operations
 pub type ZstorResult<T> = Result<T, ZstorError>;
 
+/// Handles to the actors of a running zstor system.
+pub struct ZstorSystem {
+    /// Address of the main zstor actor, which processes store, retrieve, rebuild and check
+    /// commands.
+    pub zstor: Addr<ZstorActor>,
+    /// Address of the repair actor, which sweeps the metastore for degraded objects and
+    /// rebuilds them.
+    pub repairer: Addr<RepairActor>,
+}
+
 /// Start the 0-stor monitor daemon
-pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<Addr<ZstorActor>> {
+pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<ZstorSystem> {
     let metastore = match cfg.meta() {
         Meta::Zdb(zdb_cfg) => {
             let backends = join_all(
@@ -101,6 +111,7 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<Addr<Z
         explorer,
         metrics_addr.clone(),
         meta_addr.clone(),
+        cfg.missing_backend_grace(),
     )
     .start();
 
@@ -115,7 +126,14 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<Addr<Z
 
     let _ = DirMonitorActor::new(cfg_addr.clone(), zstor.clone()).start();
 
-    let _ = RepairActor::new(meta_addr, backends, zstor.clone()).start();
+    let repairer = RepairActor::new(
+        meta_addr,
+        backends,
+        zstor.clone(),
+        cfg_addr,
+        cfg.repair_interval(),
+    )
+    .start();
 
     // Setup prometheus endpoint if needed
     if let Some(port) = prom_port {
@@ -130,7 +148,7 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<Addr<Z
         });
     };
 
-    Ok(zstor)
+    Ok(ZstorSystem { zstor, repairer })
 }
 
 /// Load a TOML encoded config file from the given path.

--- a/zstor/src/lib.rs
+++ b/zstor/src/lib.rs
@@ -124,7 +124,13 @@ pub async fn setup_system(cfg_path: PathBuf, cfg: &Config) -> ZstorResult<ZstorS
     )
     .start();
 
-    let _ = DirMonitorActor::new(cfg_addr.clone(), zstor.clone()).start();
+    let _ = DirMonitorActor::new(
+        cfg_addr.clone(),
+        zstor.clone(),
+        metrics_addr.clone(),
+        cfg.zdb_data_dir_check_interval(),
+    )
+    .start();
 
     let repairer = RepairActor::new(
         meta_addr,

--- a/zstor/src/main.rs
+++ b/zstor/src/main.rs
@@ -19,6 +19,7 @@ use structopt::StructOpt;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 use zstor_v2::actors::config::ReloadConfig;
+use zstor_v2::actors::repairer::{RepairActor, SweepNow, SweepReport};
 use zstor_v2::actors::zstor::{Check, Rebuild, Retrieve, Store, ZstorCommand, ZstorResponse};
 use zstor_v2::actors::zstor_scheduler::Signaled;
 use zstor_v2::actors::zstor_scheduler::ZstorActorScheduler;
@@ -184,6 +185,15 @@ enum Cmd {
     /// the health of the backends. This info inludes if the backend is reachable, and the amount
     /// of used and free storage space.
     Status,
+
+    /// Run a repair sweep over all stored objects
+    ///
+    /// Scans all stored objects, and rebuilds every object which has one or more shards on an
+    /// unreachable backend onto healthy backends. This is the same scan the monitor runs
+    /// periodically when unattended repair is enabled; running it through this command works
+    /// regardless of that setting, so repair can be driven by an external scheduler. Prints a
+    /// summary of the sweep when it completes.
+    Sweep,
 }
 
 /// ModuleFilter is a naive log filter which only allows (child modules of) a given module.
@@ -331,6 +341,7 @@ async fn real_main() -> ZstorResult<()> {
         Cmd::Check { file } => {
             handle_command(ZstorCommand::Check(Check { path: file }), opts.config).await?
         }
+        Cmd::Sweep => handle_command(ZstorCommand::Sweep(SweepNow), opts.config).await?,
         Cmd::Test => {
             // load config => already done
             // connect to metastore => already done
@@ -500,7 +511,9 @@ async fn real_main() -> ZstorResult<()> {
             table.printstd();
         }
         Cmd::Monitor => {
-            let zstor = zstor_v2::setup_system(opts.config, &cfg).await?;
+            let system = zstor_v2::setup_system(opts.config, &cfg).await?;
+            let zstor = system.zstor;
+            let repairer = system.repairer;
             let mut pid_path = PathBuf::from("/var/run/zstor.pid");
             if let Some(cfg_pid_file) = cfg.pid_file() {
                 if let Some(v) = cfg_pid_file.to_str() {
@@ -541,9 +554,10 @@ async fn real_main() -> ZstorResult<()> {
                             Ok((con, remote)) => (con, remote),
                         };
                         let zs = zstor_scheduler.clone();
+                        let rep = repairer.clone();
                         tokio::spawn(async move {
                             debug!("Handling new client connection from {:?}", remote);
-                            if let Err(e) = handle_client(con, zs).await {
+                            if let Err(e) = handle_client(con, zs, rep).await {
                                 error!("Error while handeling client: {}", e);
                             }
                         });
@@ -592,7 +606,11 @@ async fn real_main() -> ZstorResult<()> {
     Ok(())
 }
 
-async fn handle_client<C>(mut con: C, zstor: Addr<ZstorActorScheduler>) -> ZstorResult<()>
+async fn handle_client<C>(
+    mut con: C,
+    zstor: Addr<ZstorActorScheduler>,
+    repairer: Addr<RepairActor>,
+) -> ZstorResult<()>
 where
     C: AsyncRead + AsyncWrite + Unpin,
 {
@@ -628,6 +646,10 @@ where
             Err(e) => ZstorResponse::Err(e.to_string()),
             Ok(Some(checksum)) => ZstorResponse::Checksum(checksum),
             Ok(None) => ZstorResponse::Success,
+        },
+        ZstorCommand::Sweep(sweep) => match repairer.send(sweep).await? {
+            Err(e) => ZstorResponse::Err(e.to_string()),
+            Ok(report) => ZstorResponse::Sweep(report),
         },
     };
 
@@ -670,6 +692,7 @@ async fn handle_command(zc: ZstorCommand, cfg_path: PathBuf) -> Result<(), Zstor
 
         match res {
             ZstorResponse::Checksum(checksum) => println!("{}", hex::encode(checksum)),
+            ZstorResponse::Sweep(report) => print_sweep_report(&report),
             ZstorResponse::Err(err) => {
                 eprintln!("Zstor error: {}", err);
                 process::exit(1);
@@ -678,7 +701,8 @@ async fn handle_command(zc: ZstorCommand, cfg_path: PathBuf) -> Result<(), Zstor
         }
     } else {
         debug!("No zstor daemon socket found, running command in process");
-        let zstor = zstor_v2::setup_system(cfg_path, &cfg).await?;
+        let system = zstor_v2::setup_system(cfg_path, &cfg).await?;
+        let zstor = system.zstor;
         match zc {
             ZstorCommand::Store(store) => zstor.send(store).await??,
             ZstorCommand::Retrieve(retrieve) => zstor.send(retrieve).await??,
@@ -688,9 +712,20 @@ async fn handle_command(zc: ZstorCommand, cfg_path: PathBuf) -> Result<(), Zstor
                     println!("{}", hex::encode(checksum));
                 }
             }
+            ZstorCommand::Sweep(sweep) => {
+                let report = system.repairer.send(sweep).await??;
+                print_sweep_report(&report);
+            }
         };
     };
     Ok(())
+}
+
+fn print_sweep_report(report: &SweepReport) {
+    println!(
+        "repair sweep finished: {} objects checked, {} degraded, {} rebuilt, {} failed",
+        report.objects, report.degraded, report.rebuilt, report.failed
+    );
 }
 
 #[allow(clippy::result_large_err)]

--- a/zstor/tests/cache_eviction.rs
+++ b/zstor/tests/cache_eviction.rs
@@ -1,0 +1,52 @@
+//! Integration test for the data dir cache eviction, run against real 0-db processes. See
+//! `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is found
+//! (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::{setup_cache_rig, write_test_file};
+use std::time::{Duration, Instant};
+use zstor_v2::actors::zstor::Retrieve;
+
+#[actix_rt::test]
+async fn eviction_removes_dispersed_files_only() {
+    // A 1 MiB cap checked every second, holding one dispersed 700 KiB file.
+    let Some((rig, data_dir)) = setup_cache_rig("evict", 1, 1, 700 * 1024, false).await else {
+        return;
+    };
+
+    // A second file which is never dispersed pushes the dir over its cap.
+    let undispersed = data_dir.join("d1");
+    write_test_file(&undispersed, 7, 700 * 1024);
+
+    // The monitor must evict the dispersed file (bringing the dir back under the cap) and
+    // must leave the undispersed file alone: deleting it would lose data.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline && rig.data_file.exists() {
+        actix_rt::time::sleep(Duration::from_millis(250)).await;
+    }
+    assert!(
+        !rig.data_file.exists(),
+        "the dispersed file was never evicted from the over-cap data dir"
+    );
+    assert!(
+        undispersed.exists(),
+        "a file which was never dispersed must not be evicted"
+    );
+
+    // An eviction is only acceptable if the evicted file can come back: retrieve it and
+    // verify the content survived the round trip.
+    rig.system
+        .zstor
+        .send(Retrieve {
+            file: rig.data_file.clone(),
+        })
+        .await
+        .expect("can deliver retrieve command")
+        .expect("retrieve succeeds");
+    let restored = std::fs::read(&rig.data_file).expect("can read restored file");
+    assert_eq!(
+        restored, rig.payload,
+        "restored object content differs from the original"
+    );
+}

--- a/zstor/tests/cache_eviction_symlink.rs
+++ b/zstor/tests/cache_eviction_symlink.rs
@@ -1,0 +1,47 @@
+//! Integration test for data dir cache eviction through a symlinked data dir path, run
+//! against real 0-db processes. Regression test: the metastore keys files by the path they
+//! were stored with, without resolving symlinks. Older versions resolved the path on the
+//! filesystem before the eviction lookup, so a data dir reached through a symlink (a mounted
+//! or relocated volume) never matched its own metadata and nothing was ever evicted.
+//!
+//! See `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is
+//! found (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::setup_cache_rig;
+use std::time::{Duration, Instant};
+use zstor_v2::actors::zstor::Retrieve;
+
+#[actix_rt::test]
+async fn eviction_works_through_symlinked_data_dir() {
+    // A single dispersed 1.3 MiB file in a symlinked data dir capped at 1 MiB: the dir is
+    // over its cap from the start, so the monitor must evict the file.
+    let Some((rig, _data_dir)) = setup_cache_rig("symlink", 1, 1, 1300 * 1024, true).await else {
+        return;
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline && rig.data_file.exists() {
+        actix_rt::time::sleep(Duration::from_millis(250)).await;
+    }
+    assert!(
+        !rig.data_file.exists(),
+        "the dispersed file in the symlinked data dir was never evicted"
+    );
+
+    // The evicted file must still be retrievable through the same (symlinked) path.
+    rig.system
+        .zstor
+        .send(Retrieve {
+            file: rig.data_file.clone(),
+        })
+        .await
+        .expect("can deliver retrieve command")
+        .expect("retrieve succeeds");
+    let restored = std::fs::read(&rig.data_file).expect("can read restored file");
+    assert_eq!(
+        restored, rig.payload,
+        "restored object content differs from the original"
+    );
+}

--- a/zstor/tests/common/mod.rs
+++ b/zstor/tests/common/mod.rs
@@ -1,0 +1,284 @@
+//! Integration tests for the repair sweep, run against real 0-db processes.
+//!
+//! These tests need a 0-db binary: set the ZDB_BINARY environment variable to its path, or
+//! have `zdb` on the PATH. When no binary is found the tests print a notice and pass without
+//! testing anything, so the regular test suite stays independent of external tools.
+
+use std::io::Write;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use zstor_v2::actors::zstor::{Retrieve, Store};
+use zstor_v2::config::{Compression, Config, Encryption, Group, Meta};
+use zstor_v2::encryption::SymmetricKey;
+use zstor_v2::meta::new_metastore;
+use zstor_v2::zdb::ZdbConnectionInfo;
+use zstor_v2::zdb_meta::ZdbMetaStoreConfig;
+use zstor_v2::ZstorSystem;
+
+/// Locate the 0-db binary to run the tests against.
+fn zdb_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("ZDB_BINARY") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    for dir in std::env::split_paths(&std::env::var_os("PATH")?) {
+        for name in ["zdb", "zdbd"] {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// A running fleet of 0-db processes, killed and cleaned up on drop.
+pub struct ZdbFleet {
+    root: PathBuf,
+    children: Vec<(u16, Option<Child>)>,
+}
+
+impl ZdbFleet {
+    fn spawn(bin: &Path, root: PathBuf, seq_ports: &[u16], user_ports: &[u16]) -> ZdbFleet {
+        let mut children = Vec::new();
+        for (mode, ports) in [("seq", seq_ports), ("user", user_ports)] {
+            for &port in ports {
+                let dir = root.join(format!("zdb-{}", port));
+                std::fs::create_dir_all(&dir).expect("can create zdb dir");
+                let child = Command::new(bin)
+                    .arg("--port")
+                    .arg(port.to_string())
+                    .arg("--listen")
+                    .arg("127.0.0.1")
+                    .arg("--data")
+                    .arg(dir.join("data"))
+                    .arg("--index")
+                    .arg(dir.join("index"))
+                    .arg("--mode")
+                    .arg(mode)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("can spawn zdb");
+                children.push((port, Some(child)));
+            }
+        }
+        let fleet = ZdbFleet { root, children };
+        for (port, _) in &fleet.children {
+            wait_reachable(*port);
+        }
+        fleet
+    }
+
+    /// Kill the 0-db listening on the given port.
+    pub fn kill_port(&mut self, port: u16) {
+        for (p, child) in self.children.iter_mut() {
+            if *p == port {
+                if let Some(mut child) = child.take() {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+                return;
+            }
+        }
+        panic!("no zdb running on port {}", port);
+    }
+}
+
+impl Drop for ZdbFleet {
+    fn drop(&mut self) {
+        for (_, child) in self.children.iter_mut() {
+            if let Some(mut child) = child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn wait_reachable(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("zdb on port {} did not come up", port);
+}
+
+/// Reserve a set of distinct free localhost ports.
+fn free_ports(amount: usize) -> Vec<u16> {
+    let listeners: Vec<TcpListener> = (0..amount)
+        .map(|_| TcpListener::bind("127.0.0.1:0").expect("can bind localhost"))
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().expect("bound socket has an address").port())
+        .collect()
+}
+
+fn local_ci(port: u16) -> ZdbConnectionInfo {
+    let addr: SocketAddr = format!("127.0.0.1:{}", port)
+        .parse()
+        .expect("valid localhost address");
+    ZdbConnectionInfo::new(addr, None, None)
+}
+
+/// Build a config over the given fleet: every data backend forms its own group, so repair
+/// target selection can be observed keeping the group spread.
+fn make_config(
+    root: &Path,
+    data_ports: &[u16],
+    meta_ports: &[u16],
+    unattended_repair: bool,
+    repair_interval_secs: u64,
+) -> Config {
+    let meta_backends: [ZdbConnectionInfo; 4] = [
+        local_ci(meta_ports[0]),
+        local_ci(meta_ports[1]),
+        local_ci(meta_ports[2]),
+        local_ci(meta_ports[3]),
+    ];
+    Config {
+        minimal_shards: 2,
+        expected_shards: 4,
+        redundant_groups: 0,
+        redundant_nodes: 0,
+        root: Some(root.to_path_buf()),
+        socket: None,
+        pid_file: None,
+        zdb_data_dir_path: None,
+        max_zdb_data_dir_size: None,
+        zdbfs_mountpoint: None,
+        prometheus_port: None,
+        unattended_repair: Some(unattended_repair),
+        repair_interval_secs: Some(repair_interval_secs),
+        missing_backend_grace_secs: Some(1),
+        encryption: Encryption::Aes(SymmetricKey::new([3u8; 32])),
+        compression: Compression::Snappy,
+        meta: Meta::Zdb(ZdbMetaStoreConfig::new(
+            "repairtest".to_string(),
+            Encryption::Aes(SymmetricKey::new([4u8; 32])),
+            meta_backends,
+        )),
+        groups: data_ports
+            .iter()
+            .map(|&port| Group {
+                backends: vec![local_ci(port)],
+            })
+            .collect(),
+    }
+}
+
+pub struct TestRig {
+    pub fleet: ZdbFleet,
+    pub cfg: Config,
+    pub system: ZstorSystem,
+    pub data_file: PathBuf,
+    pub payload: Vec<u8>,
+}
+
+/// Stand up a fleet, a zstor system over it, and one stored object. Returns None when no zdb
+/// binary is available.
+pub async fn setup_rig(
+    name: &str,
+    unattended_repair: bool,
+    repair_interval_secs: u64,
+) -> Option<TestRig> {
+    let Some(bin) = zdb_binary() else {
+        eprintln!("skipping repair integration test: no zdb binary found (set ZDB_BINARY)");
+        return None;
+    };
+
+    let root = std::env::temp_dir().join(format!("zstor-repair-{}-{}", name, std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("can create test root");
+
+    let ports = free_ports(9);
+    let data_ports = ports[..5].to_vec();
+    let meta_ports = ports[5..].to_vec();
+    let fleet = ZdbFleet::spawn(&bin, root.clone(), &data_ports, &meta_ports);
+
+    let cfg = make_config(
+        &root,
+        &data_ports,
+        &meta_ports,
+        unattended_repair,
+        repair_interval_secs,
+    );
+    let system = zstor_v2::setup_system(root.join("zstor.toml"), &cfg)
+        .await
+        .expect("can set up zstor system");
+
+    // A payload which spans several erasure blocks and doesn't compress away entirely.
+    let payload: Vec<u8> = (0..200 * 1024u32)
+        .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
+        .collect();
+    let data_file = root.join("data.bin");
+    let mut file = std::fs::File::create(&data_file).expect("can create data file");
+    file.write_all(&payload).expect("can write data file");
+    drop(file);
+
+    system
+        .zstor
+        .send(Store {
+            file: data_file.clone(),
+            key_path: None,
+            save_failure: false,
+            delete: false,
+            blocking: true,
+        })
+        .await
+        .expect("can deliver store command")
+        .expect("store succeeds");
+
+    Some(TestRig {
+        fleet,
+        cfg,
+        system,
+        data_file,
+        payload,
+    })
+}
+
+/// The ports of the data backends currently referenced by the stored object's metadata.
+pub async fn shard_ports(cfg: &Config, path: &Path) -> Vec<u16> {
+    let meta = new_metastore(cfg)
+        .await
+        .expect("can build metastore client");
+    let metadata = meta
+        .load_meta(path)
+        .await
+        .expect("can load metadata")
+        .expect("metadata for stored object exists");
+    metadata
+        .shards()
+        .iter()
+        .map(|shard| shard.zdb().address().port())
+        .collect()
+}
+
+/// Retrieve the object (after deleting the local copy) and verify its content is intact.
+pub async fn verify_retrievable(rig: &TestRig) {
+    std::fs::remove_file(&rig.data_file).expect("can delete local copy");
+    rig.system
+        .zstor
+        .send(Retrieve {
+            file: rig.data_file.clone(),
+        })
+        .await
+        .expect("can deliver retrieve command")
+        .expect("retrieve succeeds");
+    let restored = std::fs::read(&rig.data_file).expect("can read restored file");
+    assert_eq!(
+        restored, rig.payload,
+        "restored object content differs from the original"
+    );
+}

--- a/zstor/tests/common/mod.rs
+++ b/zstor/tests/common/mod.rs
@@ -157,13 +157,16 @@ fn local_ci(port: u16) -> ZdbConnectionInfo {
 }
 
 /// Build a config over the given fleet: every data backend forms its own group, so repair
-/// target selection can be observed keeping the group spread.
+/// target selection can be observed keeping the group spread. When `data_dir` is given, the
+/// data dir monitor is configured with that (path, size cap in MiB, check interval in
+/// seconds).
 fn make_config(
     root: &Path,
     data_ports: &[u16],
     meta_ports: &[u16],
     unattended_repair: bool,
     repair_interval_secs: u64,
+    data_dir: Option<(&Path, u64, u64)>,
 ) -> Config {
     let meta_backends: [ZdbConnectionInfo; 4] = [
         local_ci(meta_ports[0]),
@@ -179,8 +182,9 @@ fn make_config(
         root: Some(root.to_path_buf()),
         socket: None,
         pid_file: None,
-        zdb_data_dir_path: None,
-        max_zdb_data_dir_size: None,
+        zdb_data_dir_path: data_dir.map(|(path, _, _)| path.to_path_buf()),
+        max_zdb_data_dir_size: data_dir.map(|(_, cap_mib, _)| cap_mib),
+        zdb_data_dir_check_interval_secs: data_dir.map(|(_, _, interval)| interval),
         zdbfs_mountpoint: None,
         prometheus_port: None,
         unattended_repair: Some(unattended_repair),
@@ -245,6 +249,7 @@ pub async fn setup_rig(
         &meta_ports,
         unattended_repair,
         repair_interval_secs,
+        None,
     );
     let system = zstor_v2::setup_system(root.join("zstor.toml"), &cfg)
         .await
@@ -279,6 +284,93 @@ pub async fn setup_rig(
         data_file,
         payload,
     })
+}
+
+/// Write a deterministic test payload of the given length to the given path, and return it.
+pub fn write_test_file(path: &Path, seed: u32, len: usize) -> Vec<u8> {
+    let payload: Vec<u8> = (0..len as u32)
+        .map(|i| (i.wrapping_mul(2654435761).wrapping_add(seed) >> 13) as u8)
+        .collect();
+    std::fs::write(path, &payload).expect("can write test file");
+    payload
+}
+
+/// Stand up a fleet and a zstor system with the data dir monitor enabled: a data dir capped
+/// at `cap_mib` MiB, checked every `interval_secs` seconds, holding one dispersed file of
+/// `file_len` bytes (the rig's `data_file`). With `via_symlink` the configured data dir path
+/// goes through a symlink, like a data dir on a mounted or relocated volume would. Returns
+/// the rig and the data dir path as configured. Returns None when no zdb binary is available.
+pub async fn setup_cache_rig(
+    name: &str,
+    cap_mib: u64,
+    interval_secs: u64,
+    file_len: usize,
+    via_symlink: bool,
+) -> Option<(TestRig, PathBuf)> {
+    let Some(bin) = zdb_binary() else {
+        eprintln!("skipping cache integration test: no zdb binary found (set ZDB_BINARY)");
+        return None;
+    };
+
+    let root = std::env::temp_dir().join(format!("zstor-cache-{}-{}", name, std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("can create test root");
+
+    let ports = free_ports(9);
+    let data_ports = ports[..5].to_vec();
+    let meta_ports = ports[5..].to_vec();
+    let fleet = ZdbFleet::spawn(&bin, root.clone(), &data_ports, &meta_ports);
+
+    let data_dir = if via_symlink {
+        let real = root.join("realdir");
+        std::fs::create_dir_all(&real).expect("can create real data dir");
+        let link = root.join("datadir");
+        std::os::unix::fs::symlink(&real, &link).expect("can create data dir symlink");
+        link
+    } else {
+        let dir = root.join("datadir");
+        std::fs::create_dir_all(&dir).expect("can create data dir");
+        dir
+    };
+
+    let cfg = make_config(
+        &root,
+        &data_ports,
+        &meta_ports,
+        false,
+        600,
+        Some((&data_dir, cap_mib, interval_secs)),
+    );
+    let system = zstor_v2::setup_system(root.join("zstor.toml"), &cfg)
+        .await
+        .expect("can set up zstor system");
+
+    let data_file = data_dir.join("d0");
+    let payload = write_test_file(&data_file, 1, file_len);
+
+    system
+        .zstor
+        .send(Store {
+            file: data_file.clone(),
+            key_path: None,
+            save_failure: false,
+            delete: false,
+            blocking: true,
+        })
+        .await
+        .expect("can deliver store command")
+        .expect("store succeeds");
+
+    Some((
+        TestRig {
+            fleet,
+            cfg,
+            system,
+            data_file,
+            payload,
+        },
+        data_dir,
+    ))
 }
 
 /// The ports of the data backends currently referenced by the stored object's metadata.

--- a/zstor/tests/common/mod.rs
+++ b/zstor/tests/common/mod.rs
@@ -1,8 +1,11 @@
-//! Integration tests for the repair sweep, run against real 0-db processes.
+//! Shared harness for the integration tests which run against real 0-db processes.
 //!
 //! These tests need a 0-db binary: set the ZDB_BINARY environment variable to its path, or
 //! have `zdb` on the PATH. When no binary is found the tests print a notice and pass without
 //! testing anything, so the regular test suite stays independent of external tools.
+
+// This module is compiled once per test binary, and not every binary uses every helper.
+#![allow(dead_code)]
 
 use std::io::Write;
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -39,8 +42,29 @@ fn zdb_binary() -> Option<PathBuf> {
 
 /// A running fleet of 0-db processes, killed and cleaned up on drop.
 pub struct ZdbFleet {
+    bin: PathBuf,
     root: PathBuf,
-    children: Vec<(u16, Option<Child>)>,
+    children: Vec<(u16, String, Option<Child>)>,
+}
+
+fn spawn_one(bin: &Path, root: &Path, port: u16, mode: &str) -> Child {
+    let dir = root.join(format!("zdb-{}", port));
+    std::fs::create_dir_all(&dir).expect("can create zdb dir");
+    Command::new(bin)
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--listen")
+        .arg("127.0.0.1")
+        .arg("--data")
+        .arg(dir.join("data"))
+        .arg("--index")
+        .arg(dir.join("index"))
+        .arg("--mode")
+        .arg(mode)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("can spawn zdb")
 }
 
 impl ZdbFleet {
@@ -48,28 +72,16 @@ impl ZdbFleet {
         let mut children = Vec::new();
         for (mode, ports) in [("seq", seq_ports), ("user", user_ports)] {
             for &port in ports {
-                let dir = root.join(format!("zdb-{}", port));
-                std::fs::create_dir_all(&dir).expect("can create zdb dir");
-                let child = Command::new(bin)
-                    .arg("--port")
-                    .arg(port.to_string())
-                    .arg("--listen")
-                    .arg("127.0.0.1")
-                    .arg("--data")
-                    .arg(dir.join("data"))
-                    .arg("--index")
-                    .arg(dir.join("index"))
-                    .arg("--mode")
-                    .arg(mode)
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .spawn()
-                    .expect("can spawn zdb");
-                children.push((port, Some(child)));
+                let child = spawn_one(bin, &root, port, mode);
+                children.push((port, mode.to_string(), Some(child)));
             }
         }
-        let fleet = ZdbFleet { root, children };
-        for (port, _) in &fleet.children {
+        let fleet = ZdbFleet {
+            bin: bin.to_path_buf(),
+            root,
+            children,
+        };
+        for (port, _, _) in &fleet.children {
             wait_reachable(*port);
         }
         fleet
@@ -77,7 +89,7 @@ impl ZdbFleet {
 
     /// Kill the 0-db listening on the given port.
     pub fn kill_port(&mut self, port: u16) {
-        for (p, child) in self.children.iter_mut() {
+        for (p, _, child) in self.children.iter_mut() {
             if *p == port {
                 if let Some(mut child) = child.take() {
                     let _ = child.kill();
@@ -88,11 +100,24 @@ impl ZdbFleet {
         }
         panic!("no zdb running on port {}", port);
     }
+
+    /// Restart a previously killed 0-db on its old port, over its surviving data dirs.
+    pub fn respawn_port(&mut self, port: u16) {
+        for (p, mode, child) in self.children.iter_mut() {
+            if *p == port {
+                assert!(child.is_none(), "zdb on port {} is still running", port);
+                *child = Some(spawn_one(&self.bin, &self.root, port, mode));
+                wait_reachable(port);
+                return;
+            }
+        }
+        panic!("no zdb known on port {}", port);
+    }
 }
 
 impl Drop for ZdbFleet {
     fn drop(&mut self) {
-        for (_, child) in self.children.iter_mut() {
+        for (_, _, child) in self.children.iter_mut() {
             if let Some(mut child) = child.take() {
                 let _ = child.kill();
                 let _ = child.wait();
@@ -161,6 +186,7 @@ fn make_config(
         unattended_repair: Some(unattended_repair),
         repair_interval_secs: Some(repair_interval_secs),
         missing_backend_grace_secs: Some(1),
+        degraded_write_margin: None,
         encryption: Encryption::Aes(SymmetricKey::new([3u8; 32])),
         compression: Compression::Snappy,
         meta: Meta::Zdb(ZdbMetaStoreConfig::new(
@@ -183,6 +209,13 @@ pub struct TestRig {
     pub system: ZstorSystem,
     pub data_file: PathBuf,
     pub payload: Vec<u8>,
+}
+
+impl TestRig {
+    /// The root directory of the test fleet, usable for additional scratch files.
+    pub fn fleet_root(&self) -> &Path {
+        &self.fleet.root
+    }
 }
 
 /// Stand up a fleet, a zstor system over it, and one stored object. Returns None when no zdb

--- a/zstor/tests/degraded_write.rs
+++ b/zstor/tests/degraded_write.rs
@@ -1,0 +1,144 @@
+//! Integration test for degraded writes, run against real 0-db processes. See
+//! `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is found
+//! (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::{setup_rig, shard_ports, verify_retrievable};
+use std::time::{Duration, Instant};
+use zstor_v2::actors::repairer::SweepNow;
+use zstor_v2::actors::zstor::Store;
+
+/// With one backend dead and no spare (4 configured for 4 shards), a write must degrade to 3
+/// placed shards instead of stalling; once the backend returns, a repair sweep must backfill
+/// the object to full redundancy. With two backends dead, a write must be refused: 2 healthy
+/// equals the minimal shards, which is below minimal + margin.
+#[actix_rt::test]
+async fn writes_degrade_survive_and_backfill() {
+    // The rig starts 5 data backends but only the first 4 form the write set of the initial
+    // object; the point here is a config with NO spare, so build the degraded config over
+    // the 4 backends the object landed on and kill within that set. Simplest equivalent: use
+    // the rig as-is (5 configured backends), kill TWO backends holding shards - leaving 3
+    // healthy of the 5 - so a full 4-shard placement is impossible but a degraded 3-shard
+    // write (minimal 2 + margin 1) is allowed.
+    let Some(mut rig) = setup_rig("degraded", false, 3600).await else {
+        return;
+    };
+
+    let used = shard_ports(&rig.cfg, &rig.data_file).await;
+    assert_eq!(used.len(), 4);
+    let (victim_a, victim_b) = (used[0], used[1]);
+    rig.fleet.kill_port(victim_a);
+    rig.fleet.kill_port(victim_b);
+
+    // Write a NEW object while 2 of 5 backends are dead. Full placement (4 shards on 4
+    // distinct healthy backends) is impossible with 3 healthy; the write must degrade to 3
+    // shards instead of failing.
+    let payload: Vec<u8> = (0..64 * 1024u32)
+        .map(|i| (i.wrapping_mul(40503) >> 7) as u8)
+        .collect();
+    let degraded_file = rig.fleet_root().join("degraded.bin");
+    std::fs::write(&degraded_file, &payload).expect("can write second data file");
+
+    rig.system
+        .zstor
+        .send(Store {
+            file: degraded_file.clone(),
+            key_path: None,
+            save_failure: false,
+            delete: false,
+            blocking: true,
+        })
+        .await
+        .expect("can deliver store command")
+        .expect("store must succeed degraded instead of stalling");
+
+    let degraded_shards = shard_ports(&rig.cfg, &degraded_file).await;
+    assert_eq!(
+        degraded_shards.len(),
+        3,
+        "degraded write should place exactly as many shards as healthy backends"
+    );
+    assert!(!degraded_shards.contains(&victim_a));
+    assert!(!degraded_shards.contains(&victim_b));
+
+    // The degraded object must be readable.
+    std::fs::remove_file(&degraded_file).expect("can delete local copy");
+    rig.system
+        .zstor
+        .send(zstor_v2::actors::zstor::Retrieve {
+            file: degraded_file.clone(),
+        })
+        .await
+        .expect("can deliver retrieve command")
+        .expect("degraded object must be retrievable");
+    assert_eq!(
+        std::fs::read(&degraded_file).expect("can read restored file"),
+        payload
+    );
+
+    // Bring one dead backend back (its data dirs survived the kill), then sweep: the
+    // degraded object must be backfilled to full redundancy, and the object from setup
+    // (which lost 2 of its 4 shards) must be repaired too.
+    rig.fleet.respawn_port(victim_a);
+
+    // Sweep until both objects are whole again; a single sweep may only manage one of the
+    // two repairs depending on how quickly the backend manager notices the comeback.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut backfilled = false;
+    while Instant::now() < deadline {
+        let report = rig
+            .system
+            .repairer
+            .send(SweepNow)
+            .await
+            .expect("can deliver sweep command")
+            .expect("sweep completes");
+        assert_eq!(report.objects, 2, "sweep should inspect both objects");
+        let degraded_now = shard_ports(&rig.cfg, &degraded_file).await;
+        let original_now = shard_ports(&rig.cfg, &rig.data_file).await;
+        if degraded_now.len() == 4
+            && !degraded_now.contains(&victim_b)
+            && !original_now.contains(&victim_b)
+        {
+            backfilled = true;
+            break;
+        }
+        actix_rt::time::sleep(Duration::from_secs(2)).await;
+    }
+    assert!(
+        backfilled,
+        "sweep never backfilled the degraded object and repaired the original"
+    );
+
+    verify_retrievable(&rig).await;
+
+    // Finally: kill backends down to exactly the minimal shard count (2 healthy). A write
+    // must now be refused - minimal + margin(1) = 3 healthy required.
+    let remaining = shard_ports(&rig.cfg, &degraded_file).await;
+    let extra_victim = *remaining
+        .iter()
+        .find(|p| **p != victim_a)
+        .expect("a third backend is in use");
+    rig.fleet.kill_port(extra_victim);
+    rig.fleet.kill_port(victim_a);
+
+    let refused_file = rig.fleet_root().join("refused.bin");
+    std::fs::write(&refused_file, &payload).expect("can write third data file");
+    let result = rig
+        .system
+        .zstor
+        .send(Store {
+            file: refused_file,
+            key_path: None,
+            save_failure: false,
+            delete: false,
+            blocking: true,
+        })
+        .await
+        .expect("can deliver store command");
+    assert!(
+        result.is_err(),
+        "a write below minimal shards + margin must be refused"
+    );
+}

--- a/zstor/tests/repair_sweep_disabled.rs
+++ b/zstor/tests/repair_sweep_disabled.rs
@@ -1,0 +1,46 @@
+//! Integration test for the repair sweep, run against real 0-db processes. See
+//! `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is found
+//! (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::{setup_rig, shard_ports, verify_retrievable};
+use std::time::Duration;
+use zstor_v2::actors::repairer::SweepNow;
+
+#[actix_rt::test]
+async fn disabled_unattended_repair_keeps_hands_off() {
+    let Some(mut rig) = setup_rig("disabled", false, 2).await else {
+        return;
+    };
+
+    let used = shard_ports(&rig.cfg, &rig.data_file).await;
+    let victim = used[0];
+    rig.fleet.kill_port(victim);
+
+    // Give the (2 second) sweep interval ample ticks; with unattended repair disabled the
+    // metadata must remain untouched.
+    actix_rt::time::sleep(Duration::from_secs(15)).await;
+    let ports = shard_ports(&rig.cfg, &rig.data_file).await;
+    assert!(
+        ports.contains(&victim),
+        "repair ran although unattended repair is disabled"
+    );
+
+    // An explicitly requested sweep still repairs.
+    let report = rig
+        .system
+        .repairer
+        .send(SweepNow)
+        .await
+        .expect("can deliver sweep command")
+        .expect("sweep completes");
+    assert_eq!(report.degraded, 1);
+    assert_eq!(report.rebuilt, 1);
+    assert_eq!(report.failed, 0);
+
+    let after = shard_ports(&rig.cfg, &rig.data_file).await;
+    assert!(!after.contains(&victim));
+
+    verify_retrievable(&rig).await;
+}

--- a/zstor/tests/repair_sweep_periodic.rs
+++ b/zstor/tests/repair_sweep_periodic.rs
@@ -1,0 +1,38 @@
+//! Integration test for the repair sweep, run against real 0-db processes. See
+//! `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is found
+//! (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::{setup_rig, shard_ports, verify_retrievable};
+use std::time::{Duration, Instant};
+
+#[actix_rt::test]
+async fn periodic_sweep_repairs_lost_backend_unattended() {
+    let Some(mut rig) = setup_rig("periodic", true, 2).await else {
+        return;
+    };
+
+    let used = shard_ports(&rig.cfg, &rig.data_file).await;
+    let victim = used[0];
+    rig.fleet.kill_port(victim);
+
+    // No sweep is requested: the periodic sweep alone must notice the dead backend and
+    // rebuild the object.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut repaired = false;
+    while Instant::now() < deadline {
+        let ports = shard_ports(&rig.cfg, &rig.data_file).await;
+        if !ports.contains(&victim) {
+            repaired = true;
+            break;
+        }
+        actix_rt::time::sleep(Duration::from_secs(2)).await;
+    }
+    assert!(
+        repaired,
+        "unattended repair never rebuilt the object after backend loss"
+    );
+
+    verify_retrievable(&rig).await;
+}

--- a/zstor/tests/repair_sweep_requested.rs
+++ b/zstor/tests/repair_sweep_requested.rs
@@ -1,0 +1,57 @@
+//! Integration test for the repair sweep, run against real 0-db processes. See
+//! `common/mod.rs` for the shared harness; the test is skipped when no 0-db binary is found
+//! (set ZDB_BINARY or have `zdb` on the PATH).
+
+mod common;
+
+use common::{setup_rig, shard_ports, verify_retrievable};
+use std::time::{Duration, Instant};
+use zstor_v2::actors::repairer::SweepNow;
+
+#[actix_rt::test]
+async fn requested_sweep_repairs_lost_backend() {
+    let Some(mut rig) = setup_rig("sweepnow", false, 3600).await else {
+        return;
+    };
+
+    let used = shard_ports(&rig.cfg, &rig.data_file).await;
+    assert_eq!(used.len(), 4, "object should hold 4 shards");
+    let victim = used[0];
+    rig.fleet.kill_port(victim);
+
+    // The backend manager needs a few of its 3 second check ticks to see the death and move
+    // the backend past the (1 second) grace period. Sweep until the object is repaired.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut repaired = false;
+    while Instant::now() < deadline {
+        let report = rig
+            .system
+            .repairer
+            .send(SweepNow)
+            .await
+            .expect("can deliver sweep command")
+            .expect("sweep completes");
+        assert_eq!(report.objects, 1, "sweep should inspect the stored object");
+        if report.rebuilt == 1 {
+            assert_eq!(report.degraded, 1);
+            assert_eq!(report.failed, 0);
+            repaired = true;
+            break;
+        }
+        assert_eq!(
+            report.failed, 0,
+            "sweep must not fail rebuilds while a spare backend is available"
+        );
+        actix_rt::time::sleep(Duration::from_secs(2)).await;
+    }
+    assert!(repaired, "sweep never repaired the object");
+
+    let after = shard_ports(&rig.cfg, &rig.data_file).await;
+    assert!(
+        !after.contains(&victim),
+        "metadata still references the dead backend after repair"
+    );
+    assert_eq!(after.len(), 4, "object should again hold 4 shards");
+
+    verify_retrievable(&rig).await;
+}


### PR DESCRIPTION
Fixes #159. Builds on #161 and #162 (same branch line); the eviction changes themselves are in 1ca6b94.

## The problem

As described in #159, the data dir cache cap never actually evicts anything: the cache grows until the disk is full, and the filesystem above then corrupts the running application with no operator signal anywhere.

Two defects compound here:

1. **One bad file starved the whole pass.** The eviction loop returned on the first per-file error. A file that vanishes between the directory listing and the removal attempt is routine while dispersal retries delete files on their own cadence (and exactly what a backlogged data dir under disk pressure produces), so every pass died at the head of the (oldest-first) queue and never reached the files that were evictable.
2. **Failure was silent.** A pass that ended still over the cap logged nothing actionable, so the operator's first signal was application corruption.

## The fix

- Per-file problems skip to the next candidate; a file that is already gone stops counting toward the directory size.
- A pass that ends still over the cap logs a WARN with counts (evicted / kept because not dispersed / failed), and prometheus gains `data_dir_size_bytes`, `data_dir_size_limit_bytes`, `data_dir_files_evicted`, `data_dir_eviction_failures` so disk pressure is visible before the disk fills.
- A file is only deleted after its content checksum matches the dispersed copy, so an eviction can always be undone by a retrieve.
- The eviction metadata lookup queries the path as stored and falls back to the filesystem-resolved form, so data dirs reached through a symlink evict correctly. Retrieve gets the same fallback: the store pipeline keys metadata by the resolved path, so retrieving a file through a symlinked location previously found no metadata at all — with a symlinked data dir, the hook's retrieve path was broken independent of eviction.
- The monitor runs a check immediately at startup and on a configurable interval (`zdb_data_dir_check_interval_secs`, default 60 as before).

## Tests

Two integration tests run the monitor against real 0-db processes (skipped when no `zdb` binary is available, same harness as the repair sweep tests):

- an over-cap data dir evicts the dispersed file, keeps the never-dispersed file, and the evicted file remains retrievable with intact content;
- a symlinked data dir evicts and retrieves correctly (regression for the path-form mismatch).

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, and the full test suite are green.
